### PR TITLE
Add community post images, social lists, and ranking fixes

### DIFF
--- a/app.py
+++ b/app.py
@@ -39,10 +39,13 @@ app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///users.db'
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
 PROFILE_UPLOAD_FOLDER = os.path.join(app.root_path, "static", "uploads", "profile_pictures")
+COMMUNITY_UPLOAD_FOLDER = os.path.join(app.root_path, "static", "uploads", "community_posts")
 ALLOWED_IMAGE_EXTENSIONS = {"png", "jpg", "jpeg", "gif", "webp"}
 
 app.config["PROFILE_UPLOAD_FOLDER"] = PROFILE_UPLOAD_FOLDER
+app.config["COMMUNITY_UPLOAD_FOLDER"] = COMMUNITY_UPLOAD_FOLDER
 os.makedirs(PROFILE_UPLOAD_FOLDER, exist_ok=True)
+os.makedirs(COMMUNITY_UPLOAD_FOLDER, exist_ok=True)
 
 db = SQLAlchemy(app)
 
@@ -69,6 +72,7 @@ class User(db.Model):
     bio = db.Column(db.String(280), default="")
     profile_photo = db.Column(db.String(255), default="")
     profile_public = db.Column(db.Boolean, default=True)
+    show_follow_lists = db.Column(db.Boolean, default=True)
 
 
 class Workout(db.Model):
@@ -123,6 +127,17 @@ class Follow(db.Model):
     )
 
 
+class FollowRequest(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    requester_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    target_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+
+    __table_args__ = (
+        db.UniqueConstraint("requester_id", "target_id", name="unique_follow_request"),
+    )
+
+
 class WorkoutLike(db.Model):
     id = db.Column(db.Integer, primary_key=True)
 
@@ -158,6 +173,38 @@ class CalendarEntry(db.Model):
     __table_args__ = (db.UniqueConstraint('user_id', 'date', name='uq_cal_user_date'),)
 
 
+class CommunityPost(db.Model):
+    __tablename__ = "community_post"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    body = db.Column(db.Text, default="")
+    image_path = db.Column(db.String(255), nullable=True)
+    plan_id = db.Column(db.Integer, db.ForeignKey("workout_plan.id"), nullable=True)
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+    is_public = db.Column(db.Boolean, default=True)
+    user = db.relationship("User", backref="community_posts")
+    plan = db.relationship("WorkoutPlan", backref="community_posts")
+
+
+class CommunityPostLike(db.Model):
+    __tablename__ = "community_post_like"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    post_id = db.Column(db.Integer, db.ForeignKey("community_post.id"), nullable=False)
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+    __table_args__ = (db.UniqueConstraint("user_id", "post_id", name="unique_cp_like"),)
+
+
+class CommunityPostComment(db.Model):
+    __tablename__ = "community_post_comment"
+    id = db.Column(db.Integer, primary_key=True)
+    body = db.Column(db.Text, nullable=False)
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    post_id = db.Column(db.Integer, db.ForeignKey("community_post.id"), nullable=False)
+    user = db.relationship("User", backref="community_post_comments")
+
+
 # ── Create DB ──
 with app.app_context():
     db.create_all()
@@ -166,7 +213,20 @@ with app.app_context():
 PLAN_COLORS = ['#534AB7', '#085041', '#712B13', '#633806', '#27500A', '#1A5276', '#4A154B', '#6D1A36']
 
 # ── Rank tier thresholds ──
-TIER_THRESHOLDS = [
+# Thresholds for the leaderboard (total accumulated volume: weight × reps across all sets)
+LEADERBOARD_TIER_THRESHOLDS = [
+    (500000, 'Champion', '🏆', 'rb-champion'),
+    (300000, 'Emerald',  '💚', 'rb-emerald'),
+    (180000, 'Diamond',  '💎', 'rb-diamond'),
+    (100000, 'Platinum', '🔷', 'rb-platinum'),
+    (50000,  'Gold',     '🥇', 'rb-gold'),
+    (20000,  'Silver',   '🥈', 'rb-silver'),
+    (5000,   'Bronze',   '🥉', 'rb-bronze'),
+    (0,      'Unranked', '—',  'rb-unranked'),
+]
+
+# Thresholds for My Ranks (per-muscle-group PR score: best_weight × best_reps per exercise)
+RANK_TIER_THRESHOLDS = [
     (100000, 'Champion', '🏆', 'rb-champion'),
     (50000,  'Emerald',  '💚', 'rb-emerald'),
     (25000,  'Diamond',  '💎', 'rb-diamond'),
@@ -226,14 +286,16 @@ EXERCISE_MUSCLE_MAP = {
 }
 
 
-def get_tier(points):
+def get_tier(points, thresholds=None):
+    if thresholds is None:
+        thresholds = LEADERBOARD_TIER_THRESHOLDS
     v = int(points or 0)
-    for i, (threshold, name, icon, css) in enumerate(TIER_THRESHOLDS):
+    for i, (threshold, name, icon, css) in enumerate(thresholds):
         if v >= threshold:
             if i == 0:
                 pct, next_threshold, next_name = 100, None, None
             else:
-                next_threshold, next_name, _, _ = TIER_THRESHOLDS[i - 1]
+                next_threshold, next_name, _, _ = thresholds[i - 1]
                 pct = min(99, int((v - threshold) / (next_threshold - threshold) * 100))
             return {
                 'name': name, 'icon': icon, 'css': css,
@@ -269,7 +331,7 @@ def get_muscle_group_data(user_id):
     muscle_data = {}
     for g in MUSCLE_GROUPS:
         cfg = MUSCLE_CONFIG[g]
-        tier = get_tier(group_points[g])
+        tier = get_tier(group_points[g], RANK_TIER_THRESHOLDS)
         muscle_data[g] = {
             'label':      cfg['label'],
             'letter':     cfg['letter'],
@@ -288,7 +350,7 @@ def get_muscle_group_data(user_id):
 
     total_points = sum(group_points.values())
     avg_points = total_points / len(MUSCLE_GROUPS)
-    overall_t = get_tier(avg_points)
+    overall_t = get_tier(avg_points, RANK_TIER_THRESHOLDS)
     overall_tier = {**overall_t, 'total_points': total_points}
 
     return muscle_data, overall_tier
@@ -390,16 +452,14 @@ def get_day_streak(user_id):
 
 
 def get_user_rank(user_id):
-    start_of_week = get_start_of_week()
-
+    """Returns the user's position in the all-time leaderboard (1 = highest volume)."""
     leaderboard_data = (
         db.session.query(
             User.id,
-            func.sum(WorkoutSet.weight * WorkoutSet.reps).label('weekly_volume')
+            func.sum(WorkoutSet.weight * WorkoutSet.reps).label('total_volume')
         )
         .join(Workout, Workout.user_id == User.id)
         .join(WorkoutSet, WorkoutSet.workout_id == Workout.id)
-        .filter(Workout.date >= start_of_week)
         .group_by(User.id)
         .order_by(func.sum(WorkoutSet.weight * WorkoutSet.reps).desc())
         .all()
@@ -410,6 +470,18 @@ def get_user_rank(user_id):
             return index
 
     return None
+
+
+def get_volume_tier(user_id):
+    """Returns a tier dict based on a user's total all-time workout volume (weight × reps).
+    Consistent with the all-time leaderboard tier shown on the leaderboard page."""
+    vol = (
+        db.session.query(func.sum(WorkoutSet.weight * WorkoutSet.reps))
+        .join(Workout, Workout.id == WorkoutSet.workout_id)
+        .filter(Workout.user_id == user_id)
+        .scalar()
+    ) or 0
+    return get_tier(int(vol))
 
 def get_current_streak(user_id):
     workouts = (
@@ -917,41 +989,42 @@ def leaderboard():
         session.clear()
         return redirect('/login')
 
-    start_of_week = get_start_of_week()
-
     leaderboard_data = (
         db.session.query(
             User.id,
             User.username,
             User.profile_photo,
             func.count(func.distinct(Workout.id)).label('workouts_count'),
-            func.sum(WorkoutSet.weight * WorkoutSet.reps).label('weekly_volume')
+            func.sum(WorkoutSet.weight * WorkoutSet.reps).label('total_volume')
         )
         .join(Workout, Workout.user_id == User.id)
         .join(WorkoutSet, WorkoutSet.workout_id == Workout.id)
-        .filter(Workout.date >= start_of_week)
         .group_by(User.id, User.username, User.profile_photo)
         .order_by(func.sum(WorkoutSet.weight * WorkoutSet.reps).desc())
         .all()
     )
 
     tier_map = {
-        item.id: get_tier(item.weekly_volume or 0)
+        item.id: get_tier(item.total_volume or 0)
         for item in leaderboard_data
     }
 
-    # PR count and strength score per user
+    # PR count and strength score per user.
+    # Strength score = sum of (best_weight × best_reps) across all PersonalRecord entries —
+    # a peak-strength metric distinct from the raw accumulated-volume score used for tier badges.
     all_prs = PersonalRecord.query.all()
     pr_count_map = {}
+    pr_score_map = {}
     for pr in all_prs:
         pr_count_map[pr.user_id] = pr_count_map.get(pr.user_id, 0) + 1
+        pr_score_map[pr.user_id] = pr_score_map.get(pr.user_id, 0) + int(pr.best_weight * pr.best_reps)
 
-    strength_map = {uid: tier['points'] for uid, tier in tier_map.items()}
+    strength_map = {uid: pr_score_map.get(uid, 0) for uid in tier_map}
 
     # Achievement badges — one winner per category
     badges_map = {}
     if leaderboard_data:
-        vol_w = max(leaderboard_data, key=lambda r: r.weekly_volume or 0)
+        vol_w = max(leaderboard_data, key=lambda r: r.total_volume or 0)
         badges_map.setdefault(vol_w.id, []).append('vol')
         freq_w = max(leaderboard_data, key=lambda r: r.workouts_count or 0)
         badges_map.setdefault(freq_w.id, []).append('freq')
@@ -971,7 +1044,6 @@ def leaderboard():
         user=user,
         rank=get_user_rank(session['user_id']),
         today=datetime.now(timezone.utc),
-        week_num=datetime.now(timezone.utc).isocalendar()[1],
     )
 
 
@@ -1187,6 +1259,15 @@ def profile():
         return redirect('/login')
 
     if request.method == 'POST':
+        form_action = request.form.get('form_action', 'profile')
+
+        if form_action == 'privacy':
+            user.profile_public = 'profile_private' not in request.form
+            user.show_follow_lists = 'show_follow_lists' in request.form
+            db.session.commit()
+            flash("Privacy settings updated.")
+            return redirect(url_for('profile'))
+
         user.bio = request.form.get('bio', '').strip()[:280]
 
         photo = request.files.get('profile_photo')
@@ -1216,7 +1297,7 @@ def profile():
     )
 
     rank = get_user_rank(session['user_id'])
-    _, overall_tier = get_muscle_group_data(session['user_id'])
+    overall_tier = get_volume_tier(session['user_id'])
     day_streak = get_day_streak(session['user_id'])
 
     recent_workouts = (
@@ -1262,6 +1343,14 @@ def profile():
         ).get('icon_color', '#333'),
     } for p in prs]
 
+    pending_requests = (
+        FollowRequest.query
+        .filter_by(target_id=user.id)
+        .order_by(FollowRequest.created_at.desc())
+        .all()
+    )
+    requesters = {fr.id: db.session.get(User, fr.requester_id) for fr in pending_requests}
+
     return render_template(
         'profile.html',
         user=user,
@@ -1271,6 +1360,8 @@ def profile():
         day_streak=day_streak,
         recent_workouts=workout_cards,
         pr_list=pr_list,
+        pending_requests=pending_requests,
+        requesters=requesters,
     )
 
 
@@ -1313,90 +1404,147 @@ def _require_login():
     return user, None
 
 
-@app.route("/feed")
+@app.route("/feed", methods=["GET", "POST"])
 def public_feed():
     user, err = _require_login()
     if err:
         return err
 
+    # ── Create post (POST) ──
+    if request.method == "POST":
+        body = request.form.get("body", "").strip()
+        plan_id_str = request.form.get("plan_id", "").strip()
+        image_path = None
+
+        photo = request.files.get("image")
+        if photo and photo.filename:
+            if not allowed_image_file(photo.filename) or not allowed_image_mimetype(photo):
+                flash("Please upload a valid image: png, jpg, jpeg, gif, or webp.", "warning")
+                return redirect(url_for("public_feed"))
+            ext = photo.filename.rsplit(".", 1)[1].lower()
+            unique_name = f"post_{user.id}_{uuid4().hex}.{ext}"
+            photo.save(os.path.join(app.config["COMMUNITY_UPLOAD_FOLDER"], unique_name))
+            image_path = f"uploads/community_posts/{unique_name}"
+
+        if not body and not image_path:
+            flash("A post needs some text or an image.", "warning")
+            return redirect(url_for("public_feed"))
+
+        plan_id = None
+        if plan_id_str:
+            try:
+                pid_int = int(plan_id_str)
+                plan_obj = WorkoutPlan.query.get(pid_int)
+                if plan_obj and plan_obj.user_id == user.id:
+                    plan_id = pid_int
+            except (ValueError, TypeError):
+                pass
+
+        db.session.add(CommunityPost(
+            user_id=user.id,
+            body=body,
+            image_path=image_path,
+            plan_id=plan_id,
+            is_public=True,
+        ))
+        db.session.commit()
+        flash("Post shared!", "success")
+        return redirect(url_for("public_feed"))
+
+    # ── Read feed (GET) ──
     feed_filter = request.args.get("filter", "all")
-    base_q = WorkoutPlan.query.filter_by(is_public=True)
+
+    followed_ids = {
+        f.followed_id
+        for f in Follow.query.filter_by(follower_id=user.id).all()
+    }
+
+    # Only show posts from public profiles, profiles the current user follows,
+    # or the current user's own posts.
+    base_q = (
+        CommunityPost.query
+        .join(User, User.id == CommunityPost.user_id)
+        .filter(
+            CommunityPost.is_public == True,
+            db.or_(
+                User.profile_public == True,
+                CommunityPost.user_id.in_(followed_ids),
+                CommunityPost.user_id == user.id,
+            )
+        )
+    )
 
     if feed_filter == "liked":
-        plans = (
+        posts = (
             base_q
-            .outerjoin(WorkoutLike, WorkoutLike.workout_id == WorkoutPlan.id)
-            .group_by(WorkoutPlan.id)
-            .order_by(func.count(WorkoutLike.id).desc(), WorkoutPlan.id.desc())
+            .outerjoin(CommunityPostLike, CommunityPostLike.post_id == CommunityPost.id)
+            .group_by(CommunityPost.id)
+            .order_by(func.count(CommunityPostLike.id).desc(), CommunityPost.id.desc())
             .all()
         )
     elif feed_filter == "following":
-        followed_ids = [
-            f.followed_id
-            for f in Follow.query.filter_by(follower_id=user.id).all()
-        ]
-        plans = (
+        posts = (
             base_q
-            .filter(WorkoutPlan.user_id.in_(followed_ids))
-            .order_by(WorkoutPlan.id.desc())
+            .filter(CommunityPost.user_id.in_(followed_ids))
+            .order_by(CommunityPost.created_at.desc())
             .all()
         ) if followed_ids else []
     else:
-        plans = base_q.order_by(WorkoutPlan.id.desc()).all()
+        posts = base_q.order_by(CommunityPost.created_at.desc()).all()
 
-    plan_ids = [p.id for p in plans]
+    post_ids = [p.id for p in posts]
     likes_map = {}
     comments_map = {}
     comments_preview_map = {}
     liked_by_user_set = set()
 
-    if plan_ids:
-        like_rows = (
-            db.session.query(WorkoutLike.workout_id, func.count(WorkoutLike.id))
-            .filter(WorkoutLike.workout_id.in_(plan_ids))
-            .group_by(WorkoutLike.workout_id)
+    if post_ids:
+        for pid_val, cnt in (
+            db.session.query(CommunityPostLike.post_id, func.count(CommunityPostLike.id))
+            .filter(CommunityPostLike.post_id.in_(post_ids))
+            .group_by(CommunityPostLike.post_id)
             .all()
-        )
-        likes_map = {wid: cnt for wid, cnt in like_rows}
+        ):
+            likes_map[pid_val] = cnt
 
-        comment_rows = (
-            db.session.query(WorkoutComment.workout_id, func.count(WorkoutComment.id))
-            .filter(WorkoutComment.workout_id.in_(plan_ids))
-            .group_by(WorkoutComment.workout_id)
+        for pid_val, cnt in (
+            db.session.query(CommunityPostComment.post_id, func.count(CommunityPostComment.id))
+            .filter(CommunityPostComment.post_id.in_(post_ids))
+            .group_by(CommunityPostComment.post_id)
             .all()
-        )
-        comments_map = {wid: cnt for wid, cnt in comment_rows}
+        ):
+            comments_map[pid_val] = cnt
 
         liked_by_user_set = {
-            lk.workout_id for lk in
-            WorkoutLike.query.filter(
-                WorkoutLike.workout_id.in_(plan_ids),
-                WorkoutLike.user_id == user.id
+            lk.post_id for lk in
+            CommunityPostLike.query.filter(
+                CommunityPostLike.post_id.in_(post_ids),
+                CommunityPostLike.user_id == user.id,
             ).all()
         }
 
-        for pid in plan_ids:
+        for pid_val in post_ids:
             preview = (
-                WorkoutComment.query
-                .filter_by(workout_id=pid)
-                .order_by(WorkoutComment.created_at.desc())
+                CommunityPostComment.query
+                .filter_by(post_id=pid_val)
+                .order_by(CommunityPostComment.created_at.desc())
                 .limit(2)
                 .all()
             )
             if preview:
-                comments_preview_map[pid] = preview
+                comments_preview_map[pid_val] = preview
 
-    tags_map = {p.id: get_plan_tags(p) for p in plans}
+    my_plans = WorkoutPlan.query.filter_by(user_id=user.id).order_by(WorkoutPlan.id.desc()).all()
 
     return render_template(
         "feed.html",
-        plans=plans,
+        posts=posts,
         feed_filter=feed_filter,
         likes_map=likes_map,
         comments_map=comments_map,
         comments_preview_map=comments_preview_map,
         liked_by_user_set=liked_by_user_set,
-        tags_map=tags_map,
+        my_plans=my_plans,
     )
 
 
@@ -1409,7 +1557,7 @@ def public_profile(username):
     profile_user = User.query.filter_by(username=username).first_or_404()
     is_own_profile = profile_user.id == user.id
     profile_user_rank = get_user_rank(profile_user.id)
-    _, profile_user_tier = get_muscle_group_data(profile_user.id)
+    profile_user_tier = get_volume_tier(profile_user.id)
     nav_rank = get_user_rank(user.id)
     active_tab = request.args.get("tab", "plans")
 
@@ -1417,10 +1565,14 @@ def public_profile(username):
         follower_id=user.id, followed_id=profile_user.id
     ).first() is not None
 
+    has_pending_request = FollowRequest.query.filter_by(
+        requester_id=user.id, target_id=profile_user.id
+    ).first() is not None
+
     followers_count = Follow.query.filter_by(followed_id=profile_user.id).count()
     following_count = Follow.query.filter_by(follower_id=profile_user.id).count()
 
-    profile_visible = profile_user.profile_public or is_own_profile
+    profile_visible = profile_user.profile_public or is_own_profile or is_following
 
     # Defaults — safe fallbacks used when profile is private or data is absent
     public_plans       = []
@@ -1578,6 +1730,7 @@ def public_profile(username):
         public_plans_count=public_plans_count,
         is_own_profile=is_own_profile,
         is_following=is_following,
+        has_pending_request=has_pending_request,
         followers_count=followers_count,
         following_count=following_count,
         profile_visible=profile_visible,
@@ -1610,16 +1763,33 @@ def follow_user(user_id):
         flash("You cannot follow yourself.", "warning")
         return redirect(url_for("public_profile", username=user_to_follow.username))
 
-    existing = Follow.query.filter_by(
+    already_following = Follow.query.filter_by(
         follower_id=user.id, followed_id=user_to_follow.id
     ).first()
 
-    if not existing:
+    if already_following:
+        next_url = request.form.get("next", "")
+        if not next_url or not next_url.startswith("/"):
+            next_url = url_for("public_profile", username=user_to_follow.username)
+        return redirect(next_url)
+
+    if not user_to_follow.profile_public:
+        existing_request = FollowRequest.query.filter_by(
+            requester_id=user.id, target_id=user_to_follow.id
+        ).first()
+        if not existing_request:
+            db.session.add(FollowRequest(requester_id=user.id, target_id=user_to_follow.id))
+            db.session.commit()
+            flash(f"Follow request sent to {user_to_follow.username}.", "success")
+    else:
         db.session.add(Follow(follower_id=user.id, followed_id=user_to_follow.id))
         db.session.commit()
         flash(f"You are now following {user_to_follow.username}.", "success")
 
-    return redirect(url_for("public_profile", username=user_to_follow.username))
+    next_url = request.form.get("next", "")
+    if not next_url or not next_url.startswith("/"):
+        next_url = url_for("public_profile", username=user_to_follow.username)
+    return redirect(next_url)
 
 
 @app.route("/unfollow/<int:user_id>", methods=["POST"])
@@ -1639,7 +1809,283 @@ def unfollow_user(user_id):
         db.session.commit()
         flash(f"You unfollowed {user_to_unfollow.username}.", "info")
 
-    return redirect(url_for("public_profile", username=user_to_unfollow.username))
+    next_url = request.form.get("next", "")
+    if not next_url or not next_url.startswith("/"):
+        next_url = url_for("public_profile", username=user_to_unfollow.username)
+    return redirect(next_url)
+
+
+@app.route("/follow-request/<int:request_id>/accept", methods=["POST"])
+def accept_follow_request(request_id):
+    user, err = _require_login()
+    if err:
+        return err
+
+    fr = FollowRequest.query.get_or_404(request_id)
+
+    if fr.target_id != user.id:
+        flash("Not authorised.", "warning")
+        return redirect(url_for("profile"))
+
+    existing = Follow.query.filter_by(
+        follower_id=fr.requester_id, followed_id=fr.target_id
+    ).first()
+    if not existing:
+        db.session.add(Follow(follower_id=fr.requester_id, followed_id=fr.target_id))
+
+    requester_id = fr.requester_id
+    db.session.delete(fr)
+    db.session.commit()
+
+    requester = db.session.get(User, requester_id)
+    if requester:
+        flash(f"You accepted {requester.username}'s follow request.", "success")
+
+    return redirect(url_for("profile"))
+
+
+@app.route("/follow-request/<int:request_id>/decline", methods=["POST"])
+def decline_follow_request(request_id):
+    user, err = _require_login()
+    if err:
+        return err
+
+    fr = FollowRequest.query.get_or_404(request_id)
+
+    if fr.target_id != user.id:
+        flash("Not authorised.", "warning")
+        return redirect(url_for("profile"))
+
+    requester_id = fr.requester_id
+    db.session.delete(fr)
+    db.session.commit()
+
+    requester = db.session.get(User, requester_id)
+    if requester:
+        flash(f"You declined {requester.username}'s follow request.", "info")
+
+    return redirect(url_for("profile"))
+
+
+@app.route("/follow-request/<int:user_id>/cancel", methods=["POST"])
+def cancel_follow_request(user_id):
+    user, err = _require_login()
+    if err:
+        return err
+
+    fr = FollowRequest.query.filter_by(
+        requester_id=user.id, target_id=user_id
+    ).first()
+
+    if fr:
+        db.session.delete(fr)
+        db.session.commit()
+        target = db.session.get(User, user_id)
+        if target:
+            flash(f"Follow request to {target.username} cancelled.", "info")
+
+    target = db.session.get(User, user_id)
+    next_url = request.form.get("next", "")
+    if not next_url or not next_url.startswith("/"):
+        next_url = url_for("public_profile", username=target.username) if target else url_for("dashboard")
+    return redirect(next_url)
+
+
+# ------------------------------------------------------------
+# Social list routes: followers / following / user plans
+# ------------------------------------------------------------
+
+@app.route("/u/<username>/followers")
+def user_followers(username):
+    user, err = _require_login()
+    if err:
+        return err
+
+    profile_user = User.query.filter_by(username=username).first_or_404()
+    is_own_profile = profile_user.id == user.id
+    nav_rank = get_user_rank(user.id)
+    q = request.args.get("q", "").strip()
+
+    current_user_follows_profile = Follow.query.filter_by(
+        follower_id=user.id, followed_id=profile_user.id
+    ).first() is not None
+
+    lists_visible = (
+        is_own_profile
+        or current_user_follows_profile
+        or (profile_user.profile_public and profile_user.show_follow_lists)
+    )
+
+    if not lists_visible:
+        return render_template(
+            "social_list.html",
+            profile_user=profile_user,
+            list_type="followers",
+            users=[],
+            hidden=True,
+            is_own_profile=is_own_profile,
+            q=q,
+            following_ids=set(),
+            current_user=user,
+            nav_rank=nav_rank,
+        )
+
+    query = (
+        db.session.query(User)
+        .join(Follow, Follow.follower_id == User.id)
+        .filter(Follow.followed_id == profile_user.id)
+    )
+    if q:
+        query = query.filter(User.username.ilike(f"%{q}%"))
+    followers = query.order_by(User.username).all()
+
+    following_ids = {
+        f.followed_id
+        for f in Follow.query.filter_by(follower_id=user.id).all()
+    }
+
+    return render_template(
+        "social_list.html",
+        profile_user=profile_user,
+        list_type="followers",
+        users=followers,
+        hidden=False,
+        is_own_profile=is_own_profile,
+        q=q,
+        following_ids=following_ids,
+        current_user=user,
+        nav_rank=nav_rank,
+    )
+
+
+@app.route("/u/<username>/following")
+def user_following(username):
+    user, err = _require_login()
+    if err:
+        return err
+
+    profile_user = User.query.filter_by(username=username).first_or_404()
+    is_own_profile = profile_user.id == user.id
+    nav_rank = get_user_rank(user.id)
+    q = request.args.get("q", "").strip()
+
+    current_user_follows_profile = Follow.query.filter_by(
+        follower_id=user.id, followed_id=profile_user.id
+    ).first() is not None
+
+    lists_visible = (
+        is_own_profile
+        or current_user_follows_profile
+        or (profile_user.profile_public and profile_user.show_follow_lists)
+    )
+
+    if not lists_visible:
+        return render_template(
+            "social_list.html",
+            profile_user=profile_user,
+            list_type="following",
+            users=[],
+            hidden=True,
+            is_own_profile=is_own_profile,
+            q=q,
+            following_ids=set(),
+            current_user=user,
+            nav_rank=nav_rank,
+        )
+
+    query = (
+        db.session.query(User)
+        .join(Follow, Follow.followed_id == User.id)
+        .filter(Follow.follower_id == profile_user.id)
+    )
+    if q:
+        query = query.filter(User.username.ilike(f"%{q}%"))
+    following = query.order_by(User.username).all()
+
+    following_ids = {
+        f.followed_id
+        for f in Follow.query.filter_by(follower_id=user.id).all()
+    }
+
+    return render_template(
+        "social_list.html",
+        profile_user=profile_user,
+        list_type="following",
+        users=following,
+        hidden=False,
+        is_own_profile=is_own_profile,
+        q=q,
+        following_ids=following_ids,
+        current_user=user,
+        nav_rank=nav_rank,
+    )
+
+
+@app.route("/u/<username>/plans")
+def user_plans(username):
+    user, err = _require_login()
+    if err:
+        return err
+
+    profile_user = User.query.filter_by(username=username).first_or_404()
+    is_own_profile = profile_user.id == user.id
+    nav_rank = get_user_rank(user.id)
+    is_following = Follow.query.filter_by(
+        follower_id=user.id, followed_id=profile_user.id
+    ).first() is not None
+    profile_visible = profile_user.profile_public or is_own_profile or is_following
+
+    if not profile_visible:
+        return redirect(url_for("public_profile", username=username))
+
+    if is_own_profile:
+        plans = (
+            WorkoutPlan.query
+            .filter_by(user_id=profile_user.id)
+            .order_by(WorkoutPlan.id.desc())
+            .all()
+        )
+    else:
+        plans = (
+            WorkoutPlan.query
+            .filter_by(user_id=profile_user.id, is_public=True)
+            .order_by(WorkoutPlan.id.desc())
+            .all()
+        )
+
+    plan_ids = [p.id for p in plans]
+    likes_map = {}
+    comments_map = {}
+
+    if plan_ids:
+        like_rows = (
+            db.session.query(WorkoutLike.workout_id, func.count(WorkoutLike.id))
+            .filter(WorkoutLike.workout_id.in_(plan_ids))
+            .group_by(WorkoutLike.workout_id)
+            .all()
+        )
+        likes_map = {wid: cnt for wid, cnt in like_rows}
+
+        comment_rows = (
+            db.session.query(WorkoutComment.workout_id, func.count(WorkoutComment.id))
+            .filter(WorkoutComment.workout_id.in_(plan_ids))
+            .group_by(WorkoutComment.workout_id)
+            .all()
+        )
+        comments_map = {wid: cnt for wid, cnt in comment_rows}
+
+    tags_map = {p.id: get_plan_tags(p) for p in plans}
+
+    return render_template(
+        "user_plans.html",
+        profile_user=profile_user,
+        plans=plans,
+        is_own_profile=is_own_profile,
+        likes_map=likes_map,
+        comments_map=comments_map,
+        tags_map=tags_map,
+        nav_rank=nav_rank,
+    )
 
 
 @app.route("/workout/<int:plan_id>")
@@ -1773,6 +2219,51 @@ def toggle_plan_visibility(plan_id):
 
     next_url = request.form.get("next") or url_for("plans")
     return redirect(next_url)
+
+
+@app.route("/post/<int:post_id>/like/json", methods=["POST"])
+def toggle_post_like_json(post_id):
+    user, err = _require_login()
+    if err:
+        return jsonify({"error": "not logged in"}), 401
+
+    post = CommunityPost.query.get_or_404(post_id)
+    if not post.is_public:
+        return jsonify({"error": "private post"}), 403
+
+    existing = CommunityPostLike.query.filter_by(post_id=post.id, user_id=user.id).first()
+    if existing:
+        db.session.delete(existing)
+        liked = False
+    else:
+        db.session.add(CommunityPostLike(post_id=post.id, user_id=user.id))
+        liked = True
+
+    db.session.commit()
+    count = CommunityPostLike.query.filter_by(post_id=post.id).count()
+    return jsonify({"liked": liked, "count": count})
+
+
+@app.route("/post/<int:post_id>/comment", methods=["POST"])
+def add_post_comment(post_id):
+    user, err = _require_login()
+    if err:
+        return err
+
+    post = CommunityPost.query.get_or_404(post_id)
+    if not post.is_public:
+        flash("Cannot comment on a private post.", "danger")
+        return redirect(url_for("public_feed"))
+
+    body = request.form.get("body", "").strip()
+    if not body:
+        flash("Comment cannot be empty.", "warning")
+        return redirect(url_for("public_feed"))
+
+    db.session.add(CommunityPostComment(body=body, user_id=user.id, post_id=post.id))
+    db.session.commit()
+    flash("Comment added.", "success")
+    return redirect(url_for("public_feed"))
 
 
 @app.route("/search")

--- a/seed_data.py
+++ b/seed_data.py
@@ -1,7 +1,6 @@
 """
-Optional development helper: seeds demo users, workouts, follows, likes,
-and comments so dashboard, leaderboard, profile, community feed, and
-public profile pages have data locally.
+Development helper: seeds demo users, workouts, follows, likes,
+comments, community posts, and workout plans for a realistic demo.
 
 Run from project root:
 
@@ -15,53 +14,242 @@ Do NOT commit instance/users.db.
 """
 
 import random
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from werkzeug.security import generate_password_hash
 
-from app import app, db, User, Workout, WorkoutSet, WorkoutPlan
+from app import app, db, User, Workout, WorkoutSet, WorkoutPlan, PersonalRecord
 
-# Import social models only if they exist.
 try:
-    from app import Follow, WorkoutLike, WorkoutComment
+    from app import Follow, FollowRequest, WorkoutLike, WorkoutComment
 except ImportError:
-    Follow = None
-    WorkoutLike = None
-    WorkoutComment = None
+    Follow = FollowRequest = WorkoutLike = WorkoutComment = None
+
+try:
+    from app import CommunityPost, CommunityPostLike, CommunityPostComment
+except ImportError:
+    CommunityPost = CommunityPostLike = CommunityPostComment = None
 
 
+# ─────────────────────────────────────────────────────────────────
+#  Users
+#  (username, email, bio, profile_public, show_follow_lists)
+#
+#  Privacy demo showcase:
+#    luka    — public profile, hidden follow lists
+#               lebron & victor follow them → can view lists
+#    damian  — public profile, hidden follow lists
+#               steph & shai follow them → can view lists
+#    shaq    — public profile, hidden follow lists
+#               michael & kd follow them → can view lists
+#    kobe    — private profile + hidden follow lists
+#               lebron follows them → can view lists despite private profile
+#    russell — private profile, follow lists visible to followers
+# ─────────────────────────────────────────────────────────────────
 DEMO_USERS = [
-    ("lebron", "lebron@example.com", "I like hooping and heavy push days."),
-    ("steph", "steph@example.com", "Cardio, shooting, and consistency."),
-    ("michael", "michael@example.com", "Strength training and competition."),
-    ("shai", "shai@example.com", "Balanced workouts and mobility."),
-    ("victor", "victor@example.com", "Leg day, conditioning, and recovery."),
+    # Top NBA stars
+    ("lebron",   "lebron@example.com",   "King James in the weight room. Heavy push days and full-body conditioning. GOAT debate settled.",      True,  True),
+    ("steph",    "steph@example.com",    "Chef Curry fuelling the grind. Cardio, shooting drills, and high-rep consistency every day.",          True,  True),
+    ("michael",  "michael@example.com",  "MJ's training philosophy: no days off. Strength, explosiveness, and the will to be the best.",         True,  True),
+    ("shai",     "shai@example.com",     "SGA moving like water. Balanced workouts and elite mobility work. Function over everything.",           True,  True),
+    ("victor",   "victor@example.com",   "The Alien dominating leg day. Conditioning and recovery are the secret weapons.",                      True,  True),
+    ("kd",       "kd@example.com",       "KD's conditioning is elite. Endless shooting, core work, and pure scorer mentality.",                  True,  True),
+    ("giannis",  "giannis@example.com",  "The Greek Freak goes hard every session. Power lifting, sprint drills, and relentless volume.",        True,  True),
+    ("luka",     "luka@example.com",     "Luka cooking in the gym. High IQ meets disciplined strength work. Numbers always go up.",              True,  False),  # hidden lists
+    ("jayson",   "jayson@example.com",   "Jayson Tatum chasing greatness. Strength and cardio with zero excuses.",                              True,  True),
+    ("nikola",   "nikola@example.com",   "Joker's strength is unmatched. Squat, deadlift, clean — the big man lifts heavy.",                    True,  True),
+    ("damian",   "damian@example.com",   "Dame Time in the gym too. Game 6 Lillard goes just as hard in training as on the court.",              True,  False),  # hidden lists
+    ("kawhi",    "kawhi@example.com",    "The Klaw works in silence. Elite athleticism built through disciplined, methodical sessions.",          True,  True),
+    ("kobe",     "kobe@example.com",     "Mamba Mentality. 4am sessions, film study, and zero shortcuts. The standard is the standard.",         False, False),  # private profile + hidden lists
+    ("jimmy",    "jimmy@example.com",    "Jimmy Buckets earns everything. Late nights in the gym, cold showers, and max effort always.",          True,  True),
+    ("devin",    "devin@example.com",    "Book hitting every session. Elite scorer's mindset applied to every single lift.",                     True,  True),
+    ("anthony",  "anthony@example.com",  "Ant-Man with the bounce. Functional fitness, kettlebells, and explosive training every day.",           True,  True),
+    ("shaq",     "shaq@example.com",     "Big Diesel in the big-weight room. Old-school bodybuilding, massive volume, protein for days.",         True,  False),  # hidden lists
+    ("magic",    "magic@example.com",    "Magic's energy is infectious. Team drills, HIIT, and high energy every single session.",               True,  True),
+    ("russell",  "russell@example.com",  "Russ going full throttle. Explosive power, zero rest days, off-season mode permanently activated.",    False, True),   # private profile
+    ("larry",    "larry@example.com",    "Larry Legend keeps it old school. Precision training, film study, and a protein shake after every WOD.", True,  True),
 ]
 
 
 EXERCISES = [
-    ("Bench press", 50, 110),
-    ("Squat", 70, 150),
-    ("Deadlift", 80, 170),
-    ("Overhead press", 25, 65),
-    ("Barbell row", 40, 90),
-    ("Bicep curl", 10, 25),
-    ("Leg press", 80, 180),
-    ("Incline press", 35, 85),
+    ("Bench Press",        40,  130),
+    ("Squat",              60,  160),
+    ("Deadlift",           70,  180),
+    ("Overhead Press",     20,   80),
+    ("Barbell Row",        40,  100),
+    ("Bicep Curl",         10,   35),
+    ("Leg Press",          80,  200),
+    ("Incline Press",      30,   90),
+    ("Romanian Deadlift",  50,  130),
+    ("Leg Curl",           30,   80),
+    ("Cable Row",          30,   80),
+    ("Tricep Pushdown",    15,   40),
+    ("Lateral Raise",       5,   20),
+    ("Hip Thrust",         60,  150),
+    ("Clean and Jerk",     50,  120),
+    ("Snatch",             30,   90),
+    ("Kettlebell Swing",   16,   48),
+    ("Front Squat",        50,  130),
+    ("Chest Press",        30,   90),
+    ("Dumbbell Row",       20,   60),
 ]
 
 
-COMMENTS = [
-    "Solid session 🔥",
-    "This plan looks tough.",
-    "I might try this one.",
-    "Good volume on this workout.",
-    "Strong work — nice progression.",
+# Per-user workout frequency — lower value = more workouts = higher leaderboard volume.
+# Targets (at ~10k volume/workout over 61 days):
+#   Champion  (>500k): threshold ≤ 0.18  → 50+ workouts
+#   Emerald (300-500k): threshold 0.28-0.48 → 32-44 workouts
+#   Diamond (180-300k): threshold 0.55-0.68 → 20-27 workouts
+#   Platinum(100-180k): threshold 0.75-0.84 → 10-15 workouts
+#   Gold     (50-100k): threshold 0.88-0.90 →  6-7  workouts
+USER_ACTIVITY = {
+    "giannis":  0.10,   # Champion
+    "shaq":     0.14,   # Champion
+    "lebron":   0.18,   # Champion
+    "michael":  0.28,   # Emerald
+    "nikola":   0.35,   # Emerald
+    "victor":   0.40,   # Emerald
+    "kd":       0.44,   # Emerald
+    "magic":    0.48,   # Emerald
+    "luka":     0.55,   # Diamond
+    "russell":  0.58,   # Diamond
+    "steph":    0.62,   # Diamond
+    "jayson":   0.65,   # Diamond
+    "damian":   0.68,   # Diamond
+    "kawhi":    0.75,   # Platinum
+    "jimmy":    0.78,   # Platinum
+    "anthony":  0.80,   # Platinum
+    "devin":    0.82,   # Platinum
+    "larry":    0.84,   # Platinum
+    "shai":     0.88,   # Gold
+    "kobe":     0.90,   # Gold
+}
+
+# (title_template, description, is_public)
+PLAN_TEMPLATES = [
+    ("{name}'s Push Day",          "Chest, shoulders, and triceps — a focused hypertrophy session.",                       True),
+    ("{name}'s Pull Day",          "Back and biceps with heavy compound lifts and controlled tempo.",                       True),
+    ("{name}'s Leg Day",           "Quad-dominant with accessory hamstring and glute work.",                                True),
+    ("{name}'s Full Body",         "Total body conditioning with compound movements and supersets.",                        True),
+    ("{name}'s Cardio Blast",      "High-intensity cardio intervals and core work. Leave nothing in the tank.",            True),
+    ("{name}'s Olympic Day",       "Technique work on snatch and clean and jerk. Warm up thoroughly.",                     True),
+    ("{name}'s Powerlifting Day",  "Competition-style squat, bench, and deadlift with opening and top attempts.",          True),
+    ("{name}'s HIIT Circuit",      "12-exercise circuit, 40 s on / 20 s off, 3 rounds. Minimal rest.",                     True),
+    ("{name}'s Upper Body",        "Push/pull superset upper body workout for size and strength.",                          True),
+    ("{name}'s Secret Program",    "Private program in progress — not ready to share yet.",                                 False),
+    ("{name}'s Deload Week",       "Reduced intensity, focus on form and mobility. Necessary for long-term progress.",      False),
+]
+
+
+COMMUNITY_POSTS = [
+    "Just hit a new PR on deadlift today. Hard work is paying off.",
+    "Morning session done. 5am club is no joke but the gains are real.",
+    "Pushed through a tough session. Legs are wrecked but the mind is clear.",
+    "Rest day today — foam rolling, stretching, and a solid meal. Recovery is training too.",
+    "Shared a new workout plan. Give it a try and let me know what you think!",
+    "Six weeks into the program and I can already see the difference. Trust the process.",
+    "Deload week is humbling but necessary. Next week we go again.",
+    "Tried paused squats for the first time. Absolutely brutal. Will do again.",
+    "Nutrition is 80% of the game. Meal prepped for the whole week. Feeling prepared.",
+    "Nothing beats training with a good partner. Accountability is everything.",
+    "New PB on the bench today! Consistency over perfection, always.",
+    "Olympic lifting session this morning. The snatch is finally coming together.",
+    "Hybrid training week — long run Monday, heavy lifts Wednesday and Friday.",
+    "Competed this weekend and finished top 5. So proud of where this journey has taken me.",
+    "Full body workout complete. Every muscle group hit and zero regrets.",
+    "The mental side of training is just as important as the physical. Stay focused.",
+    "Progress check at the 3-month mark. The dedication is visible. Keep going.",
+    "New powerlifting plan posted. For those who want to go heavy and heavy only.",
+    "Love seeing everyone's progress on the community feed. Keep posting.",
+    "Five-rep max on squat today. Getting stronger every single week.",
+    "Just wrapped up a 10-week strength block. Volume was insane. PRs across the board.",
+    "Mobility work before every session is non-negotiable. Your joints will thank you.",
+    "Hit every rep today. Some days you just feel locked in.",
+    "Warm-up properly, people. Skipping it is how you get hurt.",
+]
+
+
+WORKOUT_COMMENTS = [
+    "Solid session!",
+    "This plan looks tough — I'll give it a try.",
+    "Nice volume on this workout.",
+    "Strong work — the progression is impressive.",
+    "That's some serious weight. Goals!",
+    "Great structure. Love the push/pull split.",
+    "I tried this last week — brutal but effective.",
+    "Clean program. Bookmarking this.",
+    "The consistency shows. Respect.",
+    "Love the focus on compound movements here.",
+    "Perfect rep scheme for hypertrophy.",
+    "Going to run this next cycle for sure.",
+]
+
+
+POST_COMMENTS = [
+    "Keep it up!",
+    "That's awesome progress!",
+    "Solid work, well done.",
+    "Inspiring as always!",
+    "Goals! Love seeing this.",
+    "This is what consistency looks like.",
+    "So proud of you!",
+    "Training really is the best therapy.",
+    "Respect the grind.",
+    "Can't wait to try that plan!",
+    "You're an inspiration to the community.",
+    "Exactly the mindset we need more of.",
+]
+
+
+# Specific follows wired for the privacy demo.
+# These ensure follower-only list access is demonstrable at presentation time.
+SPECIFIC_FOLLOWS = [
+    # Followers of luka (hidden lists) — can view lists
+    ("lebron",  "luka"),
+    ("victor",  "luka"),
+    # Followers of damian (hidden lists) — can view lists
+    ("steph",   "damian"),
+    ("shai",    "damian"),
+    # Followers of shaq (hidden lists) — can view lists
+    ("michael", "shaq"),
+    ("kd",      "shaq"),
+    # Follower of kobe (private profile + hidden lists) — can view lists despite private profile
+    ("lebron",  "kobe"),
+    # Mutual follows between pairs for a realistic social graph
+    ("kd",      "giannis"),
+    ("giannis", "kd"),
+    ("nikola",  "kawhi"),
+    ("kawhi",   "nikola"),
+    ("jimmy",   "magic"),
+    ("magic",   "jimmy"),
+    ("devin",   "jayson"),
+    ("jayson",  "devin"),
+    ("anthony", "larry"),
+    ("larry",   "anthony"),
+    ("lebron",  "steph"),
+    ("steph",   "lebron"),
+    ("michael", "lebron"),
+    ("lebron",  "michael"),
+    ("victor",  "shai"),
+    ("shai",    "victor"),
+]
+
+
+# Pending follow requests for private users to demo the request flow.
+# Format: (requester_username, target_username)
+# target must be a private user (profile_public=False)
+SPECIFIC_REQUESTS = [
+    # Requests to kobe (private profile + hidden lists)
+    ("steph",   "kobe"),
+    ("kd",      "kobe"),
+    ("giannis", "kobe"),
+    # Requests to russell (private profile)
+    ("victor",  "russell"),
+    ("nikola",  "russell"),
 ]
 
 
 def set_if_exists(model_obj, field_name, value):
-    """Safely set a field only if the SQLAlchemy model has it."""
     if hasattr(model_obj, field_name):
         setattr(model_obj, field_name, value)
 
@@ -72,10 +260,9 @@ def seed():
     with app.app_context():
         db.create_all()
 
-        # Create demo users.
-        for username, email, bio in DEMO_USERS:
+        # ── Users ──────────────────────────────────────────────────────
+        for username, email, bio, profile_public, show_follow_lists in DEMO_USERS:
             user = User.query.filter_by(username=username).first()
-
             if not user:
                 user = User(
                     username=username,
@@ -85,192 +272,266 @@ def seed():
                 db.session.add(user)
                 db.session.flush()
 
-            set_if_exists(user, "bio", bio)
-            set_if_exists(user, "profile_public", True)
+            set_if_exists(user, "bio",               bio)
+            set_if_exists(user, "profile_public",    profile_public)
+            set_if_exists(user, "show_follow_lists", show_follow_lists)
 
         db.session.commit()
 
-        # Create demo workouts and workout sets.
-        # Range covers the last 30 days (history) plus the current week (days 0-6)
-        # so the leaderboard, which filters by Workout.date >= start_of_week, always has data.
-        for username, _, _ in DEMO_USERS:
-            user = User.query.filter_by(username=username).first()
+        # ── Workouts and sets ──────────────────────────────────────────
+        categories   = ["Strength", "Cardio", "Upper Body", "Lower Body", "Full Body", "Olympic", "HIIT"]
+        difficulties = ["Beginner", "Intermediate", "Advanced"]
 
+        for username, *_ in DEMO_USERS:
+            user = User.query.filter_by(username=username).first()
             if not user:
                 continue
 
-            for days_ago in range(30, -1, -1):
-                # Higher hit rate for current week so leaderboard is well-populated.
-                threshold = 0.50 if days_ago <= 6 else 0.65
+            threshold = USER_ACTIVITY.get(username, 0.55)
+            for days_ago in range(60, -1, -1):
                 if rng.random() >= threshold:
                     continue
 
                 workout_date = datetime.utcnow() - timedelta(
                     days=days_ago,
-                    hours=rng.randint(0, 12),
+                    hours=rng.randint(0, 16),
                 )
 
-                # Skip if a workout already exists for this user on this date.
                 date_start = workout_date.replace(hour=0, minute=0, second=0, microsecond=0)
-                date_end = date_start + timedelta(days=1)
-                existing = Workout.query.filter(
+                date_end   = date_start + timedelta(days=1)
+                if Workout.query.filter(
                     Workout.user_id == user.id,
-                    Workout.date >= date_start,
-                    Workout.date < date_end,
-                ).first()
-                if existing:
+                    Workout.date    >= date_start,
+                    Workout.date    <  date_end,
+                ).first():
                     continue
 
-                workout = Workout(
-                    user_id=user.id,
-                    date=workout_date,
-                )
-
-                set_if_exists(workout, "is_public", True)
-                set_if_exists(workout, "title", f"{username.title()}'s Training Session")
-                set_if_exists(workout, "name", f"{username.title()}'s Training Session")
-                set_if_exists(workout, "description", "A public demo workout for the community feed.")
-                set_if_exists(workout, "notes", "A public demo workout for the community feed.")
-                set_if_exists(workout, "category", rng.choice(["Strength", "Cardio", "Upper Body", "Legs"]))
-                set_if_exists(workout, "difficulty", rng.choice(["Beginner", "Intermediate", "Advanced"]))
-
+                workout = Workout(user_id=user.id, date=workout_date)
+                set_if_exists(workout, "is_public",   rng.random() < 0.75)
+                set_if_exists(workout, "title",       f"{username.title()}'s Training Session")
+                set_if_exists(workout, "name",        f"{username.title()}'s Training Session")
+                set_if_exists(workout, "description", "Demo workout for the community feed.")
+                set_if_exists(workout, "notes",       "Demo workout for the community feed.")
+                set_if_exists(workout, "category",    rng.choice(categories))
+                set_if_exists(workout, "difficulty",  rng.choice(difficulties))
                 db.session.add(workout)
                 db.session.flush()
 
-                selected_exercises = rng.sample(
-                    EXERCISES,
-                    k=rng.randint(3, 5),
-                )
-
-                for exercise_name, min_weight, max_weight in selected_exercises:
-                    for _ in range(rng.randint(3, 4)):
-                        workout_set = WorkoutSet(
+                for ex_name, min_w, max_w in rng.sample(EXERCISES, k=rng.randint(3, 6)):
+                    for _ in range(rng.randint(3, 5)):
+                        db.session.add(WorkoutSet(
                             workout_id=workout.id,
-                            exercise=exercise_name,
-                            weight=rng.randint(min_weight, max_weight),
-                            reps=rng.randint(5, 12),
-                        )
-
-                        db.session.add(workout_set)
+                            exercise=ex_name,
+                            weight=rng.randint(min_w, max_w),
+                            reps=rng.randint(4, 12),
+                        ))
 
         db.session.commit()
 
-        # Create public WorkoutPlans so demo users appear in the community feed.
-        PLAN_TEMPLATES = [
-            ("{name}'s Push Day", "Chest, shoulders, and triceps focused session."),
-            ("{name}'s Pull Day", "Back and biceps with heavy compound lifts."),
-            ("{name}'s Leg Day", "Quad-dominant with accessory hamstring work."),
-            ("{name}'s Full Body", "Total body conditioning circuit."),
-            ("{name}'s Cardio Blast", "High-intensity cardio and core work."),
-        ]
-
-        for username, _, _ in DEMO_USERS:
+        # ── Workout plans (public and private) ────────────────────────
+        for username, *_ in DEMO_USERS:
             user = User.query.filter_by(username=username).first()
             if not user:
                 continue
 
-            existing_plans = WorkoutPlan.query.filter_by(user_id=user.id, is_public=True).count()
-            if existing_plans >= 3:
-                continue
-
-            for title_tpl, desc in rng.sample(PLAN_TEMPLATES, k=3):
+            for title_tpl, desc, is_public in rng.sample(PLAN_TEMPLATES, k=min(6, len(PLAN_TEMPLATES))):
                 title = title_tpl.format(name=username.title())
-                exists = WorkoutPlan.query.filter_by(user_id=user.id, title=title).first()
-                if exists:
+                if WorkoutPlan.query.filter_by(user_id=user.id, title=title).first():
                     continue
-                plan = WorkoutPlan(
+                db.session.add(WorkoutPlan(
                     title=title,
                     description=desc,
                     user_id=user.id,
-                    is_public=True,
-                )
-                db.session.add(plan)
+                    is_public=is_public,
+                ))
 
         db.session.commit()
 
         users = User.query.all()
-        workouts = Workout.query.all()
         plans = WorkoutPlan.query.filter_by(is_public=True).all()
 
-        # Create follows.
+        # ── Personal records derived from workout sets ─────────────────
+        for username, *_ in DEMO_USERS:
+            user = User.query.filter_by(username=username).first()
+            if not user:
+                continue
+
+            all_sets = (
+                db.session.query(WorkoutSet, Workout.date)
+                .join(Workout, Workout.id == WorkoutSet.workout_id)
+                .filter(Workout.user_id == user.id)
+                .all()
+            )
+
+            best = {}
+            for ws, date in all_sets:
+                key = ws.exercise.strip().lower()
+                pts = ws.weight * ws.reps
+                if key not in best or pts > best[key]["pts"]:
+                    best[key] = {"weight": ws.weight, "reps": ws.reps, "pts": pts, "date": date}
+
+            for key, data in best.items():
+                pr = PersonalRecord.query.filter_by(user_id=user.id, exercise=key).first()
+                if pr is None:
+                    db.session.add(PersonalRecord(
+                        user_id=user.id,
+                        exercise=key,
+                        best_weight=data["weight"],
+                        best_reps=data["reps"],
+                        date_set=data["date"],
+                    ))
+                elif data["pts"] > pr.best_weight * pr.best_reps:
+                    pr.best_weight = data["weight"]
+                    pr.best_reps   = data["reps"]
+                    pr.date_set    = data["date"]
+
+        db.session.commit()
+
+        # ── Follows ────────────────────────────────────────────────────
         if Follow:
+            # Specific follows for the privacy demo
+            for follower_name, followed_name in SPECIFIC_FOLLOWS:
+                follower = User.query.filter_by(username=follower_name).first()
+                followed = User.query.filter_by(username=followed_name).first()
+                if not follower or not followed:
+                    continue
+                if not Follow.query.filter_by(follower_id=follower.id, followed_id=followed.id).first():
+                    db.session.add(Follow(follower_id=follower.id, followed_id=followed.id))
+
+            # Random follows (~28% probability) for a richer social graph
             for follower in users:
                 for followed in users:
                     if follower.id == followed.id:
                         continue
-
-                    # Keep it light/random, not everyone follows everyone.
-                    if rng.random() >= 0.35:
+                    if rng.random() >= 0.28:
                         continue
-
-                    existing_follow = Follow.query.filter_by(
-                        follower_id=follower.id,
-                        followed_id=followed.id,
-                    ).first()
-
-                    if not existing_follow:
-                        db.session.add(
-                            Follow(
-                                follower_id=follower.id,
-                                followed_id=followed.id,
-                            )
-                        )
+                    if not Follow.query.filter_by(follower_id=follower.id, followed_id=followed.id).first():
+                        db.session.add(Follow(follower_id=follower.id, followed_id=followed.id))
 
             db.session.commit()
 
-        # Create likes on public WorkoutPlans (what the feed displays).
-        # Skip "lebron" so the main demo account doesn't auto-like everything.
+        # ── Follow requests for private users ─────────────────────────
+        if FollowRequest:
+            for requester_name, target_name in SPECIFIC_REQUESTS:
+                requester = User.query.filter_by(username=requester_name).first()
+                target = User.query.filter_by(username=target_name).first()
+                if not requester or not target:
+                    continue
+                # Skip if requester already follows target (would have been seeded above)
+                already_follows = Follow.query.filter_by(
+                    follower_id=requester.id, followed_id=target.id
+                ).first() if Follow else None
+                if already_follows:
+                    continue
+                if not FollowRequest.query.filter_by(
+                    requester_id=requester.id, target_id=target.id
+                ).first():
+                    db.session.add(FollowRequest(
+                        requester_id=requester.id,
+                        target_id=target.id,
+                    ))
+            db.session.commit()
+
+        # ── Likes on public workout plans ──────────────────────────────
         if WorkoutLike:
             for plan in plans:
-                for user in users:
-                    if user.username == "lebron":
+                for u in users:
+                    if rng.random() >= 0.40:
                         continue
-                    if rng.random() >= 0.45:
-                        continue
-
-                    existing_like = WorkoutLike.query.filter_by(
-                        user_id=user.id,
-                        workout_id=plan.id,
-                    ).first()
-
-                    if not existing_like:
-                        db.session.add(
-                            WorkoutLike(
-                                user_id=user.id,
-                                workout_id=plan.id,
-                            )
-                        )
+                    if not WorkoutLike.query.filter_by(user_id=u.id, workout_id=plan.id).first():
+                        db.session.add(WorkoutLike(user_id=u.id, workout_id=plan.id))
 
             db.session.commit()
 
-        # Create comments on public WorkoutPlans.
+        # ── Comments on public workout plans ───────────────────────────
         if WorkoutComment:
             for plan in plans:
-                commenters = rng.sample(users, k=min(len(users), rng.randint(1, 3)))
-
-                for user in commenters:
-                    existing_comment = WorkoutComment.query.filter_by(
-                        user_id=user.id,
-                        workout_id=plan.id,
-                    ).first()
-
-                    if existing_comment:
+                for u in rng.sample(users, k=min(len(users), rng.randint(2, 6))):
+                    if WorkoutComment.query.filter_by(user_id=u.id, workout_id=plan.id).first():
                         continue
-
-                    db.session.add(
-                        WorkoutComment(
-                            user_id=user.id,
-                            workout_id=plan.id,
-                            body=rng.choice(COMMENTS),
-                        )
-                    )
+                    db.session.add(WorkoutComment(
+                        user_id=u.id,
+                        workout_id=plan.id,
+                        body=rng.choice(WORKOUT_COMMENTS),
+                    ))
 
             db.session.commit()
 
-        print(f"Seeded {len(DEMO_USERS)} demo users with workouts (current week + 30-day history).")
-        print("Created public WorkoutPlans for the community feed.")
-        print("Added follows, likes, and comments on public plans.")
-        print("Login with username 'lebron' / password 'Password123' to test.")
+        # ── Community posts ────────────────────────────────────────────
+        if CommunityPost:
+            post_pool = list(COMMUNITY_POSTS)
+            rng.shuffle(post_pool)
+            pool_idx = 0
+
+            for username, *_ in DEMO_USERS:
+                user = User.query.filter_by(username=username).first()
+                if not user:
+                    continue
+                if CommunityPost.query.filter_by(user_id=user.id).count() >= 3:
+                    continue
+
+                user_plans = WorkoutPlan.query.filter_by(user_id=user.id, is_public=True).all()
+                n_posts = rng.randint(2, 4)
+
+                for _ in range(n_posts):
+                    body = post_pool[pool_idx % len(post_pool)]
+                    pool_idx += 1
+                    linked_plan = rng.choice(user_plans) if user_plans and rng.random() < 0.4 else None
+                    created_offset = rng.randint(0, 30)
+                    db.session.add(CommunityPost(
+                        user_id=user.id,
+                        body=body,
+                        plan_id=linked_plan.id if linked_plan else None,
+                        is_public=True,
+                        created_at=datetime.now(timezone.utc) - timedelta(days=created_offset),
+                    ))
+
+            db.session.commit()
+
+            posts = CommunityPost.query.filter_by(is_public=True).all()
+
+            # Community post likes
+            if CommunityPostLike:
+                for post in posts:
+                    for u in users:
+                        if rng.random() >= 0.38:
+                            continue
+                        if not CommunityPostLike.query.filter_by(user_id=u.id, post_id=post.id).first():
+                            db.session.add(CommunityPostLike(user_id=u.id, post_id=post.id))
+                db.session.commit()
+
+            # Community post comments
+            if CommunityPostComment:
+                for post in posts:
+                    for u in rng.sample(users, k=min(len(users), rng.randint(1, 4))):
+                        if CommunityPostComment.query.filter_by(user_id=u.id, post_id=post.id).first():
+                            continue
+                        db.session.add(CommunityPostComment(
+                            user_id=u.id,
+                            post_id=post.id,
+                            body=rng.choice(POST_COMMENTS),
+                        ))
+                db.session.commit()
+
+        print(f"\nSeeded {len(DEMO_USERS)} NBA players with workouts, plans, follows, follow requests, likes, and posts.")
+        print("\nNBA roster:")
+        for username, *_ in DEMO_USERS:
+            print(f"  {username}")
+        print("\nPrivacy demo users:")
+        print("  luka    — public profile, hidden follow lists")
+        print("            lebron and victor follow them → can view their lists")
+        print("  damian  — public profile, hidden follow lists")
+        print("            steph and shai follow them → can view their lists")
+        print("  shaq    — public profile, hidden follow lists")
+        print("            michael and kd follow them → can view their lists")
+        print("  kobe    — private profile + hidden follow lists")
+        print("            lebron follows them (accepted); steph/kd/giannis have pending requests")
+        print("  russell — private profile, follow lists visible to followers")
+        print("            victor/nikola have pending follow requests")
+        print("\nFollow request demo:")
+        print("  Login as kobe    / Password123 → visit Profile to see 3 pending requests")
+        print("  Login as russell / Password123 → visit Profile to see 2 pending requests")
+        print("\nLogin: username 'lebron' / password 'Password123'")
 
 
 if __name__ == "__main__":

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -3187,3 +3187,643 @@ html.preloading, html.preloading * { transition: none !important; }
 [data-theme="dark"] .search-result-card {
   box-shadow: 0 3px 16px rgba(0,0,0,0.34), inset 0 1px 0 rgba(255,255,255,0.06);
 }
+
+/* ── Feed flash messages ─────────────────────────────────────── */
+.feed-flash {
+  margin-bottom: 12px;
+  padding: 10px 14px;
+  border-radius: var(--radius-md);
+  font-size: 13px;
+}
+.feed-flash-success { background: var(--success-bg); color: var(--success-text); }
+.feed-flash-warning { background: #fef3c7; color: #92400e; }
+.feed-flash-danger  { background: #fee2e2; color: #c53030; }
+[data-theme="dark"] .feed-flash-warning { background: rgba(254,243,199,0.15); color: #fcd34d; }
+[data-theme="dark"] .feed-flash-danger  { background: rgba(254,226,226,0.12); color: #fc8181; }
+
+/* ── Community Posts ─────────────────────────────────────────── */
+
+/* Create-post card */
+.cp-create { margin-bottom: 16px; padding: 16px; }
+
+.cp-create-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.cp-create-avatar-img {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.cp-create-avatar-init {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--purple-100, #EEEDFE);
+  color: var(--purple-600, #534AB7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.cp-textarea {
+  flex: 1;
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 10px 12px;
+  font-size: 14px;
+  font-family: inherit;
+  resize: vertical;
+  min-height: 56px;
+  background: var(--surface);
+  color: var(--text-primary);
+  transition: border-color 0.15s;
+  outline: none;
+}
+.cp-textarea:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(83,74,183,0.12);
+}
+.cp-textarea::placeholder { color: var(--text-tertiary); }
+
+.cp-img-preview {
+  margin: 0 0 12px;
+  position: relative;
+  display: inline-block;
+  max-width: 100%;
+}
+.cp-img-preview img {
+  max-height: 200px;
+  max-width: 100%;
+  border-radius: var(--radius-md);
+  object-fit: cover;
+  display: block;
+}
+.cp-img-remove {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(0,0,0,0.55);
+  color: #fff;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.cp-img-remove:hover { background: rgba(0,0,0,0.75); }
+
+.cp-create-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.cp-img-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 6px 12px;
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius-md);
+  transition: border-color 0.15s, color 0.15s;
+  white-space: nowrap;
+  user-select: none;
+}
+.cp-img-label:hover { border-color: var(--accent); color: var(--accent); }
+.cp-img-input { display: none; }
+
+.cp-plan-select {
+  flex: 1;
+  min-width: 160px;
+  max-width: 240px;
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 6px 10px;
+  font-size: 13px;
+  font-family: inherit;
+  background: var(--surface);
+  color: var(--text-primary);
+  cursor: pointer;
+  outline: none;
+}
+.cp-plan-select:focus { border-color: var(--accent); }
+
+.cp-post-btn { margin-left: auto; padding: 7px 20px; font-size: 13px; }
+
+/* Post body text */
+.cp-body {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-primary);
+  margin-bottom: 12px;
+  white-space: pre-line;
+  word-break: break-word;
+}
+
+/* Post image — full-bleed inside the card */
+.cp-post-img-wrap {
+  margin: 0 -20px 12px;
+  overflow: hidden;
+  line-height: 0;
+}
+.cp-post-img {
+  width: 100%;
+  max-height: 480px;
+  object-fit: cover;
+  display: block;
+}
+@media (min-width: 480px) {
+  .cp-post-img-wrap {
+    margin: 0 0 12px;
+    border-radius: var(--radius-md);
+  }
+}
+
+/* Linked workout plan preview */
+.cp-plan-card {
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 12px 14px;
+  margin-bottom: 12px;
+  background: var(--surface);
+}
+.cp-plan-badge {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--accent);
+  margin-bottom: 4px;
+}
+.cp-plan-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 4px;
+}
+.cp-plan-desc {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-bottom: 10px;
+  line-height: 1.45;
+}
+.cp-plan-btn { font-size: 12px; padding: 5px 14px; }
+
+/* Inline comment form */
+.cp-comment-form {
+  display: flex;
+  gap: 8px;
+  margin-top: 10px;
+  align-items: center;
+}
+.cp-comment-input {
+  flex: 1;
+  border: 1.5px solid var(--border);
+  border-radius: 20px;
+  padding: 6px 14px;
+  font-size: 13px;
+  font-family: inherit;
+  background: var(--surface);
+  color: var(--text-primary);
+  outline: none;
+  transition: border-color 0.15s;
+}
+.cp-comment-input:focus { border-color: var(--accent); }
+.cp-comment-input::placeholder { color: var(--text-tertiary); }
+
+.cp-comment-submit {
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.cp-comment-submit:hover { background: rgba(83,74,183,0.08); }
+
+/* Dark mode overrides */
+[data-theme="dark"] .cp-textarea,
+[data-theme="dark"] .cp-plan-select,
+[data-theme="dark"] .cp-comment-input {
+  background: rgba(255,255,255,0.05);
+  border-color: rgba(255,255,255,0.10);
+}
+[data-theme="dark"] .cp-textarea:focus,
+[data-theme="dark"] .cp-plan-select:focus,
+[data-theme="dark"] .cp-comment-input:focus {
+  background: rgba(255,255,255,0.08);
+  border-color: rgba(83,74,183,0.60);
+  box-shadow: inset 0 1px 4px rgba(0,0,0,0.22), 0 0 0 3px rgba(83,74,183,0.18);
+}
+[data-theme="dark"] .cp-plan-card { border-color: rgba(255,255,255,0.10); }
+[data-theme="dark"] .cp-img-label { border-color: rgba(255,255,255,0.10); }
+[data-theme="dark"] .cp-img-label:hover { border-color: rgba(83,74,183,0.60); }
+[data-theme="dark"] .cp-create,
+[data-theme="dark"] .cp-plan-card {
+  box-shadow: 0 4px 24px rgba(0,0,0,0.40), inset 0 1px 0 rgba(255,255,255,0.07);
+}
+
+/* ══════════════════════════════════════════════════════
+   Social list pages  (/u/<username>/followers|following)
+   ══════════════════════════════════════════════════════ */
+
+.sl-back-link {
+  font-size: 13px;
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 500;
+}
+.sl-back-link:hover { text-decoration: underline; }
+
+/* Search bar */
+.sl-search-form {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+.sl-search-wrap {
+  position: relative;
+  flex: 1;
+}
+.sl-search-icon {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--text-tertiary);
+  pointer-events: none;
+}
+.sl-search-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 9px 12px 9px 36px;
+  border: 1px solid var(--border-md);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: var(--font);
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.sl-search-input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(83, 74, 183, 0.12);
+}
+.sl-search-clear {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  text-decoration: none;
+  white-space: nowrap;
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  transition: color 0.15s, background 0.15s;
+}
+.sl-search-clear:hover {
+  color: var(--text-primary);
+  background: var(--surface-2);
+}
+
+/* User row list */
+.sl-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.sl-user-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 16px;
+}
+.sl-avatar-link {
+  flex-shrink: 0;
+  text-decoration: none;
+}
+.sl-avatar-img,
+.sl-avatar-init {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+.sl-avatar-init {
+  background: linear-gradient(135deg, var(--purple-600) 0%, var(--purple-400) 100%);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 15px;
+  font-weight: 600;
+}
+.sl-user-info {
+  flex: 1;
+  min-width: 0;
+}
+.sl-username {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  text-decoration: none;
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.sl-username:hover { color: var(--accent); }
+.sl-bio {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.sl-user-action { flex-shrink: 0; }
+.sl-action-btn  { font-size: 12px !important; padding: 5px 14px !important; }
+
+/* Empty and hidden states */
+.sl-empty,
+.sl-hidden {
+  text-align: center;
+  padding: 48px 24px;
+}
+.sl-empty-icon,
+.sl-hidden-icon  { font-size: 36px; margin-bottom: 12px; }
+.sl-empty-title,
+.sl-hidden-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 6px;
+}
+.sl-empty-sub,
+.sl-hidden-sub {
+  font-size: 13px;
+  color: var(--text-tertiary);
+}
+
+/* Clickable hero stat links on public profile */
+.pp-hero-stat-link {
+  text-decoration: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  color: inherit;
+  transition: color 0.15s;
+}
+.pp-hero-stat-link:hover .pp-hero-stat-val,
+.pp-hero-stat-link:hover .pp-hero-stat-lbl { color: var(--accent); }
+
+/* Hidden follow-list notice on hero card */
+.pp-follow-hidden-notice {
+  margin-top: 10px;
+  font-size: 11.5px;
+  color: var(--text-tertiary);
+  background: var(--surface-2);
+  border: 0.5px solid var(--border-md);
+  border-radius: var(--radius-sm);
+  padding: 6px 12px;
+  text-align: center;
+}
+
+/* ── Privacy settings toggle (profile page) ── */
+.privacy-toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 10px 0;
+}
+.privacy-toggle-info { flex: 1; }
+.privacy-toggle-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+  margin-bottom: 2px;
+}
+.privacy-toggle-sub {
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+.privacy-toggle {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 22px;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+.privacy-toggle input { opacity: 0; width: 0; height: 0; }
+.privacy-toggle-slider {
+  position: absolute;
+  inset: 0;
+  background: var(--gray-200);
+  border-radius: 22px;
+  transition: background 0.2s;
+  cursor: pointer;
+}
+.privacy-toggle-slider::before {
+  content: "";
+  position: absolute;
+  height: 16px;
+  width: 16px;
+  left: 3px;
+  bottom: 3px;
+  background: #fff;
+  border-radius: 50%;
+  transition: transform 0.2s;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.20);
+}
+.privacy-toggle input:checked + .privacy-toggle-slider { background: var(--accent); }
+.privacy-toggle input:checked + .privacy-toggle-slider::before { transform: translateX(18px); }
+
+/* Dark mode overrides */
+[data-theme="dark"] .sl-search-input {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(255, 255, 255, 0.10);
+}
+[data-theme="dark"] .sl-search-input:focus {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(83, 74, 183, 0.60);
+}
+[data-theme="dark"] .privacy-toggle-slider {
+  background: rgba(255, 255, 255, 0.15);
+}
+[data-theme="dark"] .privacy-toggle-slider::before {
+  background: rgba(255, 255, 255, 0.90);
+}
+
+/* Mobile */
+@media (max-width: 640px) {
+  .sl-user-row   { padding: 10px 12px; gap: 10px; }
+  .sl-avatar-img,
+  .sl-avatar-init { width: 38px; height: 38px; font-size: 13px; }
+  .sl-username   { font-size: 13px; }
+  .sl-action-btn { font-size: 11px !important; padding: 4px 10px !important; }
+}
+
+/* ══════════════════════════════════════════
+   FOLLOW REQUESTS
+══════════════════════════════════════════ */
+
+/* "Requested" button — muted pending state */
+.btn-requested {
+  background: var(--surface-2);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-md);
+  box-shadow: none;
+  cursor: pointer;
+  border-radius: var(--radius-md);
+  font-family: var(--font);
+  font-size: 14px;
+  font-weight: 500;
+  padding: 8px 20px;
+  transition: background 0.18s, color 0.18s;
+}
+.btn-requested:hover {
+  background: var(--danger-bg);
+  color: var(--danger-text);
+  border-color: transparent;
+}
+
+/* Decline button — outlined danger */
+.btn-req-decline {
+  background: transparent;
+  color: var(--danger-text);
+  border: 1px solid var(--danger-text);
+  box-shadow: none;
+  cursor: pointer;
+  border-radius: var(--radius-md);
+  font-family: var(--font);
+  font-size: 14px;
+  font-weight: 500;
+  padding: 8px 20px;
+  transition: background 0.18s, color 0.18s;
+}
+.btn-req-decline:hover {
+  background: var(--danger-bg);
+  border-color: transparent;
+}
+
+/* Section header badge */
+.follow-req-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: 10px;
+  background: var(--accent);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 600;
+  vertical-align: middle;
+  margin-left: 6px;
+}
+
+/* Individual request row */
+.follow-req-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 0;
+}
+
+/* Avatar */
+.follow-req-avatar-img {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+.follow-req-avatar-init {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: var(--accent-light);
+  color: var(--accent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 15px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+/* Text area */
+.follow-req-info {
+  flex: 1;
+  min-width: 0;
+}
+.follow-req-username {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  text-decoration: none;
+}
+.follow-req-username:hover { text-decoration: underline; }
+.follow-req-bio {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Buttons */
+.follow-req-actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+.follow-req-btn {
+  font-size: 12px !important;
+  padding: 5px 14px !important;
+}
+
+/* Dark mode */
+[data-theme="dark"] .btn-requested {
+  background: rgba(255,255,255,0.06);
+  border-color: rgba(255,255,255,0.12);
+}
+[data-theme="dark"] .btn-requested:hover {
+  background: var(--danger-bg);
+}
+
+/* Mobile */
+@media (max-width: 640px) {
+  .follow-req-card    { gap: 10px; }
+  .follow-req-actions { flex-direction: column; gap: 6px; }
+  .follow-req-btn     { width: 100%; text-align: center; }
+  .follow-req-bio     { display: none; }
+}

--- a/static/uploads/community_posts/.gitignore
+++ b/static/uploads/community_posts/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/templates/feed.html
+++ b/templates/feed.html
@@ -162,17 +162,76 @@
     {% with messages = get_flashed_messages(with_categories=true) %}
       {% if messages %}
         {% for category, message in messages %}
-          <div style="margin-bottom:12px;padding:10px 14px;background:var(--success-bg);color:var(--success-text);border-radius:var(--radius-md);font-size:13px;">
-            {{ message }}
-          </div>
+          <div class="feed-flash feed-flash-{{ category }}">{{ message }}</div>
         {% endfor %}
       {% endif %}
     {% endwith %}
 
     <div class="page-header" style="margin-bottom:16px;">
       <h1 class="page-title">Community Feed</h1>
-      <p class="page-sub">Public workout plans shared by the community</p>
+      <p class="page-sub">Share workout updates with the community</p>
     </div>
+
+    <!-- Create post card -->
+    <form method="post"
+          action="{{ url_for('public_feed') }}"
+          enctype="multipart/form-data"
+          class="cp-create fd-card">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+
+      <div class="cp-create-header">
+        <!-- Current user avatar -->
+        {% if nav_user and nav_user.profile_photo %}
+          <img src="{{ url_for('static', filename=nav_user.profile_photo) }}"
+               alt="{{ nav_user.username }}"
+               class="cp-create-avatar-img">
+        {% else %}
+          <div class="cp-create-avatar-init">
+            {{ nav_user.username[:2].upper() if nav_user else '?' }}
+          </div>
+        {% endif %}
+
+        <textarea name="body"
+                  class="cp-textarea"
+                  placeholder="Share a workout update…"
+                  rows="2"
+                  maxlength="2000"></textarea>
+      </div>
+
+      <!-- Image preview (hidden until file chosen) -->
+      <div class="cp-img-preview" id="cpImgPreview" style="display:none;">
+        <img id="cpImgPreviewImg" src="" alt="Preview">
+        <button type="button" class="cp-img-remove" id="cpImgRemove" title="Remove image">×</button>
+      </div>
+
+      <div class="cp-create-actions">
+        <!-- Image upload -->
+        <label class="cp-img-label" title="Add photo">
+          <svg width="15" height="15" viewBox="0 0 16 16" fill="none">
+            <rect x="1" y="3" width="14" height="10" rx="2" stroke="currentColor" stroke-width="1.4"/>
+            <circle cx="8" cy="8" r="2.5" stroke="currentColor" stroke-width="1.4"/>
+            <path d="M12 4h.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+          </svg>
+          Photo
+          <input type="file" name="image" accept="image/png,image/jpeg,image/gif,image/webp"
+                 class="cp-img-input" id="cpImgInput">
+        </label>
+
+        <!-- Attach plan dropdown -->
+        {% if my_plans %}
+          <select name="plan_id" class="cp-plan-select">
+            <option value="">Attach plan…</option>
+            {% for plan in my_plans %}
+              <option value="{{ plan.id }}">
+                {{ plan.title }}{% if not plan.is_public %} (private){% endif %}
+              </option>
+            {% endfor %}
+          </select>
+        {% endif %}
+
+        <button type="submit" class="btn btn-primary cp-post-btn">Post</button>
+      </div>
+    </form>
 
     <!-- Filter tabs -->
     <div class="fd-tabs" role="tablist">
@@ -191,61 +250,76 @@
     </div>
 
     <!-- Feed -->
-    {% if plans %}
+    {% if posts %}
       <div class="fd-feed">
-        {% for plan in plans %}
-          {% set likes   = likes_map.get(plan.id, 0) %}
-          {% set n_comments = comments_map.get(plan.id, 0) %}
-          {% set liked   = plan.id in liked_by_user_set %}
-          {% set previews = comments_preview_map.get(plan.id, []) %}
-          {% set tags    = tags_map.get(plan.id, ['Workout Plan']) %}
+        {% for post in posts %}
+          {% set likes      = likes_map.get(post.id, 0) %}
+          {% set n_comments = comments_map.get(post.id, 0) %}
+          {% set liked      = post.id in liked_by_user_set %}
+          {% set previews   = comments_preview_map.get(post.id, []) %}
 
-          <article class="fd-card" data-plan-id="{{ plan.id }}">
+          <article class="fd-card" data-post-id="{{ post.id }}">
 
-            <!-- Card header: avatar + user info -->
+            <!-- Card header: avatar + username + time -->
             <div class="fd-card-header">
-              <a href="{{ url_for('public_profile', username=plan.user.username) if plan.user else '#' }}"
+              <a href="{{ url_for('public_profile', username=post.user.username) if post.user else '#' }}"
                  class="fd-avatar-link">
-                {% if plan.user and plan.user.profile_photo %}
-                  <img src="{{ url_for('static', filename=plan.user.profile_photo) }}"
-                       alt="{{ plan.user.username }}"
+                {% if post.user and post.user.profile_photo %}
+                  <img src="{{ url_for('static', filename=post.user.profile_photo) }}"
+                       alt="{{ post.user.username }}"
                        class="fd-avatar fd-avatar-img">
                 {% else %}
                   <div class="fd-avatar fd-avatar-init">
-                    {{ plan.user.username[:2].upper() if plan.user else '?' }}
+                    {{ post.user.username[:2].upper() if post.user else '?' }}
                   </div>
                 {% endif %}
               </a>
               <div class="fd-user-info">
-                <a href="{{ url_for('public_profile', username=plan.user.username) if plan.user else '#' }}"
+                <a href="{{ url_for('public_profile', username=post.user.username) if post.user else '#' }}"
                    class="fd-username">
-                  {{ plan.user.username if plan.user else 'Unknown' }}
+                  {{ post.user.username if post.user else 'Unknown' }}
                 </a>
-                <span class="fd-meta">Plan #{{ plan.id }}</span>
+                <span class="fd-meta">{{ post.created_at.strftime('%b %d, %Y') }}</span>
               </div>
             </div>
 
-            <!-- Title + description -->
-            <div class="fd-title">{{ plan.title }}</div>
-            {% if plan.description %}
-              <div class="fd-desc">
-                {{ plan.description[:160] }}{% if plan.description | length > 160 %}…{% endif %}
+            <!-- Caption / body -->
+            {% if post.body %}
+              <div class="cp-body">{{ post.body }}</div>
+            {% endif %}
+
+            <!-- Post image -->
+            {% if post.image_path %}
+              <div class="cp-post-img-wrap">
+                <img src="{{ url_for('static', filename=post.image_path) }}"
+                     class="cp-post-img"
+                     alt="Post image">
               </div>
             {% endif %}
 
-            <!-- Tags -->
-            <div class="fd-tags">
-              {% for tag in tags %}
-                <span class="fd-tag">{{ tag }}</span>
-              {% endfor %}
-            </div>
+            <!-- Linked workout plan preview -->
+            {% if post.plan %}
+              <div class="cp-plan-card">
+                <div class="cp-plan-badge">Workout Plan</div>
+                <div class="cp-plan-title">{{ post.plan.title }}</div>
+                {% if post.plan.description %}
+                  <div class="cp-plan-desc">
+                    {{ post.plan.description[:120] }}{% if post.plan.description | length > 120 %}…{% endif %}
+                  </div>
+                {% endif %}
+                {% if post.plan.is_public %}
+                  <a href="{{ url_for('workout_detail', plan_id=post.plan.id) }}"
+                     class="btn btn-secondary cp-plan-btn">View Plan</a>
+                {% endif %}
+              </div>
+            {% endif %}
 
             <div class="fd-divider"></div>
 
             <!-- Action row -->
             <div class="fd-actions">
               <button class="fd-like-btn {% if liked %}liked{% endif %}"
-                      data-plan="{{ plan.id }}"
+                      data-post="{{ post.id }}"
                       data-liked="{{ 'true' if liked else 'false' }}"
                       title="{{ 'Unlike' if liked else 'Like' }}">
                 <svg class="fd-heart" width="15" height="15" viewBox="0 0 16 16" fill="none">
@@ -262,12 +336,9 @@
                 </svg>
                 {{ n_comments }}
               </span>
-
-              <a href="{{ url_for('workout_detail', plan_id=plan.id) }}"
-                 class="btn btn-secondary fd-view-btn">View Plan</a>
             </div>
 
-            <!-- Comment preview -->
+            <!-- Comment previews -->
             {% if previews %}
               <div class="fd-comments">
                 {% for c in previews %}
@@ -279,35 +350,46 @@
                   </div>
                 {% endfor %}
                 {% if n_comments > 2 %}
-                  <a href="{{ url_for('workout_detail', plan_id=plan.id) }}"
-                     class="fd-view-all">View all {{ n_comments }} comments →</a>
+                  <span class="fd-view-all">{{ n_comments }} comments</span>
                 {% endif %}
               </div>
-            {% else %}
-              <div class="fd-no-comments">No comments yet — be the first!</div>
             {% endif %}
+
+            <!-- Inline comment form -->
+            <form method="post"
+                  action="{{ url_for('add_post_comment', post_id=post.id) }}"
+                  class="cp-comment-form">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+              <input type="text"
+                     name="body"
+                     placeholder="Add a comment…"
+                     class="cp-comment-input"
+                     maxlength="500"
+                     autocomplete="off">
+              <button type="submit" class="cp-comment-submit">Post</button>
+            </form>
 
           </article>
         {% endfor %}
       </div>
 
     {% else %}
-      <!-- Empty state (per tab) -->
+      <!-- Empty state per tab -->
       <div class="fd-empty">
         {% if feed_filter == 'following' %}
           <div class="fd-empty-icon">👥</div>
-          <div class="fd-empty-title">Nobody followed yet</div>
-          <div class="fd-empty-sub">Follow other athletes to see their workouts here.</div>
+          <div class="fd-empty-title">Follow other users to see their posts here</div>
+          <div class="fd-empty-sub">Find athletes to follow and stay up to date with their training.</div>
           <a href="{{ url_for('search_page') }}" class="btn btn-primary" style="margin-top:16px;">Find people</a>
         {% elif feed_filter == 'liked' %}
           <div class="fd-empty-icon">❤️</div>
-          <div class="fd-empty-title">No liked workouts</div>
-          <div class="fd-empty-sub">No public plans have been liked yet. Be the first!</div>
+          <div class="fd-empty-title">No liked posts yet</div>
+          <div class="fd-empty-sub">Like posts from the community feed to see them here.</div>
           <a href="{{ url_for('public_feed') }}" class="btn btn-secondary" style="margin-top:16px;">Browse all</a>
         {% else %}
           <div class="fd-empty-icon">🏋️</div>
           <div class="fd-empty-title">Nothing here yet</div>
-          <div class="fd-empty-sub">Share a public workout plan to start the community feed.</div>
+          <div class="fd-empty-sub">Share a workout update or make a workout plan public to kick things off.</div>
           <a href="{{ url_for('plans') }}" class="btn btn-primary" style="margin-top:16px;">My plans</a>
         {% endif %}
       </div>
@@ -317,34 +399,62 @@
 </div>
 
 <script>
-  /* AJAX like toggle */
-  document.querySelectorAll('.fd-like-btn').forEach(btn => {
-    btn.addEventListener('click', () => {
-      const planId  = btn.dataset.plan;
+  /* Image preview for create-post form */
+  (function () {
+    const input   = document.getElementById('cpImgInput');
+    const preview = document.getElementById('cpImgPreview');
+    const img     = document.getElementById('cpImgPreviewImg');
+    const remove  = document.getElementById('cpImgRemove');
+
+    if (!input) return;
+
+    input.addEventListener('change', function () {
+      const file = this.files[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = function (e) {
+        img.src = e.target.result;
+        preview.style.display = 'block';
+      };
+      reader.readAsDataURL(file);
+    });
+
+    remove.addEventListener('click', function () {
+      input.value = '';
+      img.src = '';
+      preview.style.display = 'none';
+    });
+  })();
+
+  /* AJAX like toggle for community posts */
+  document.querySelectorAll('.fd-like-btn').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      const postId  = btn.dataset.post;
       const wasLiked = btn.dataset.liked === 'true';
+      const countEl  = btn.querySelector('.fd-like-count');
+      const newLiked = !wasLiked;
 
       /* Optimistic update */
-      const countEl = btn.querySelector('.fd-like-count');
-      const newLiked = !wasLiked;
       btn.dataset.liked = newLiked ? 'true' : 'false';
       btn.classList.toggle('liked', newLiked);
       btn.title = newLiked ? 'Unlike' : 'Like';
       countEl.textContent = parseInt(countEl.textContent, 10) + (newLiked ? 1 : -1);
 
-      fetch(`/workout/${planId}/like/json`, {
+      fetch('/post/' + postId + '/like/json', {
         method: 'POST',
         headers: {
           'X-CSRFToken': document.querySelector('meta[name="csrf-token"]').content
         }
       })
-        .then(r => r.json())
-        .then(data => {
+        .then(function (r) { return r.json(); })
+        .then(function (data) {
           if (data.error) {
-            /* Roll back on error */
+            /* Roll back */
             btn.dataset.liked = wasLiked ? 'true' : 'false';
             btn.classList.toggle('liked', wasLiked);
             btn.title = wasLiked ? 'Unlike' : 'Like';
-            countEl.textContent = data.count !== undefined ? data.count
+            countEl.textContent = data.count !== undefined
+              ? data.count
               : parseInt(countEl.textContent, 10) + (wasLiked ? 1 : -1);
             return;
           }
@@ -353,9 +463,7 @@
           btn.title = data.liked ? 'Unlike' : 'Like';
           countEl.textContent = data.count;
         })
-        .catch(() => {
-          /* Silent fail — the optimistic state stays; the server stays authoritative on refresh */
-        });
+        .catch(function () { /* silent — optimistic state stands */ });
     });
   });
 </script>

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -216,8 +216,8 @@
     <div class="page-header">
       <h1 class="page-title">Leaderboard</h1>
       <p class="page-sub">
-        Week {{ week_num }} ·
-        {{ leaderboard_data | length }} athletes this week
+        All-time ·
+        {{ leaderboard_data | length }} athletes ranked
       </p>
     </div>
 
@@ -266,7 +266,7 @@
               {% endfor %}
             </div>
             <div class="podium-score" data-uid="{{ second.id }}">
-              {{ second.weekly_volume|int }} kg
+              {{ second.total_volume|int }} kg
             </div>
             <div class="podium-block podium-block-second"><span>2</span></div>
           </div>
@@ -291,7 +291,7 @@
               {% endfor %}
             </div>
             <div class="podium-score" data-uid="{{ first.id }}">
-              {{ first.weekly_volume|int }} kg
+              {{ first.total_volume|int }} kg
             </div>
             <div class="podium-block podium-block-first"><span>1</span></div>
           </div>
@@ -316,7 +316,7 @@
               {% endfor %}
             </div>
             <div class="podium-score" data-uid="{{ third.id }}">
-              {{ third.weekly_volume|int }} kg
+              {{ third.total_volume|int }} kg
             </div>
             <div class="podium-block podium-block-third"><span>3</span></div>
           </div>
@@ -371,7 +371,7 @@
               class="lb-tbody-row {% if u.id == current_user_id %}current-user{% endif %}"
               data-uid="{{ u.id }}"
               data-tier="{{ t.name | lower }}"
-              data-vol="{{ (u.weekly_volume or 0) | int }}"
+              data-vol="{{ (u.total_volume or 0) | int }}"
               data-freq="{{ u.workouts_count or 0 }}"
               data-str="{{ u_str | int }}"
               data-pr="{{ u_pr }}"
@@ -413,7 +413,7 @@
 
                 <!-- Score (dynamically updated by JS) -->
                 <td class="lb-score-col lb-score-display" style="text-align:right;">
-                  {{ (u.weekly_volume or 0)|int | string + ' kg' }}
+                  {{ (u.total_volume or 0)|int | string + ' kg' }}
                 </td>
 
                 <!-- Tier badge -->
@@ -441,7 +441,7 @@
                 <td colspan="7">
                   <div class="lb-mini-stats">
                     <div class="lb-stat-item">
-                      <strong>{{ (u.weekly_volume or 0)|int }}</strong>
+                      <strong>{{ (u.total_volume or 0)|int }}</strong>
                       <span>kg volume</span>
                     </div>
                     <div class="lb-stat-item">

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -194,6 +194,47 @@
 
       <!-- Left: profile card -->
       <div style="display:flex;flex-direction:column;gap:14px;">
+
+        {% if pending_requests %}
+        <div class="card follow-req-section">
+          <div class="card-title">Follow Requests <span class="follow-req-badge">{{ pending_requests | length }}</span></div>
+          {% for fr in pending_requests %}
+            {% set requester = requesters.get(fr.id) %}
+            {% if requester %}
+            <div class="follow-req-card">
+              <div class="follow-req-avatar">
+                {% if requester.profile_photo %}
+                  <img src="{{ url_for('static', filename=requester.profile_photo) }}"
+                       alt="{{ requester.username }}"
+                       class="follow-req-avatar-img">
+                {% else %}
+                  <div class="follow-req-avatar-init">{{ requester.username[:2].upper() }}</div>
+                {% endif %}
+              </div>
+              <div class="follow-req-info">
+                <a href="{{ url_for('public_profile', username=requester.username) }}"
+                   class="follow-req-username">{{ requester.username }}</a>
+                {% if requester.bio %}
+                  <p class="follow-req-bio">{{ requester.bio }}</p>
+                {% endif %}
+              </div>
+              <div class="follow-req-actions">
+                <form action="{{ url_for('accept_follow_request', request_id=fr.id) }}" method="POST" style="display:inline;">
+                  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                  <button class="btn btn-primary follow-req-btn" type="submit">Accept</button>
+                </form>
+                <form action="{{ url_for('decline_follow_request', request_id=fr.id) }}" method="POST" style="display:inline;">
+                  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                  <button class="btn btn-req-decline follow-req-btn" type="submit">Decline</button>
+                </form>
+              </div>
+            </div>
+            {% if not loop.last %}<div class="card-divider"></div>{% endif %}
+            {% endif %}
+          {% endfor %}
+        </div>
+        {% endif %}
+
         <div class="card profile-overview-card">
           <form
             method="POST"
@@ -315,6 +356,39 @@
             No PRs yet — log a workout to start tracking.
           </div>
           {% endif %}
+        </div>
+
+        <!-- Privacy settings -->
+        <div class="card">
+          <div class="card-title">Privacy settings</div>
+          <form method="POST" action="{{ url_for('profile') }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <input type="hidden" name="form_action" value="privacy">
+            <div class="privacy-toggle-row">
+              <div class="privacy-toggle-info">
+                <div class="privacy-toggle-label">Private profile</div>
+                <div class="privacy-toggle-sub">Hide your profile and stats from others</div>
+              </div>
+              <label class="privacy-toggle">
+                <input type="checkbox" name="profile_private" {% if not user.profile_public %}checked{% endif %}>
+                <span class="privacy-toggle-slider"></span>
+              </label>
+            </div>
+            <div class="card-divider"></div>
+            <div class="privacy-toggle-row">
+              <div class="privacy-toggle-info">
+                <div class="privacy-toggle-label">Show followers &amp; following</div>
+                <div class="privacy-toggle-sub">Your followers can always view your lists — this controls visibility for everyone else</div>
+              </div>
+              <label class="privacy-toggle">
+                <input type="checkbox" name="show_follow_lists" {% if user.show_follow_lists %}checked{% endif %}>
+                <span class="privacy-toggle-slider"></span>
+              </label>
+            </div>
+            <button type="submit" class="btn btn-primary btn-block" style="margin-top:16px;">
+              Save settings
+            </button>
+          </form>
         </div>
 
         <a href="{{ url_for('logout') }}" class="btn btn-secondary btn-block">Sign out</a>

--- a/templates/public_profile.html
+++ b/templates/public_profile.html
@@ -200,6 +200,13 @@
                   Unfollow
                 </button>
               </form>
+            {% elif has_pending_request %}
+              <form action="{{ url_for('cancel_follow_request', user_id=profile_user.id) }}" method="POST">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <button class="btn btn-requested" type="submit" style="font-size:12px;padding:6px 16px;">
+                  Requested
+                </button>
+              </form>
             {% else %}
               <form action="{{ url_for('follow_user', user_id=profile_user.id) }}" method="POST">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
@@ -212,21 +219,35 @@
         </div>
 
         <div class="pp-hero-stats">
+          {% set follow_lists_visible = is_own_profile or is_following or (profile_user.profile_public and profile_user.show_follow_lists) %}
           <div class="pp-hero-stat">
+            {% if follow_lists_visible %}
+              <a href="{{ url_for('user_followers', username=profile_user.username) }}" class="pp-hero-stat-link">
+            {% endif %}
             <span class="pp-hero-stat-val">{{ followers_count }}</span>
             <span class="pp-hero-stat-lbl">followers</span>
+            {% if follow_lists_visible %}</a>{% endif %}
           </div>
           <div class="pp-hero-stat-divider"></div>
           <div class="pp-hero-stat">
+            {% if follow_lists_visible %}
+              <a href="{{ url_for('user_following', username=profile_user.username) }}" class="pp-hero-stat-link">
+            {% endif %}
             <span class="pp-hero-stat-val">{{ following_count }}</span>
             <span class="pp-hero-stat-lbl">following</span>
+            {% if follow_lists_visible %}</a>{% endif %}
           </div>
           <div class="pp-hero-stat-divider"></div>
           <div class="pp-hero-stat">
+            <a href="{{ url_for('user_plans', username=profile_user.username) }}" class="pp-hero-stat-link">
             <span class="pp-hero-stat-val">{{ public_plans_count }}</span>
             <span class="pp-hero-stat-lbl">public plans</span>
+            </a>
           </div>
         </div>
+        {% if not is_own_profile and not follow_lists_visible %}
+          <div class="pp-follow-hidden-notice">🔒 This user only shares their followers and following lists with followers.</div>
+        {% endif %}
       </div>
     </div>
 

--- a/templates/ranks.html
+++ b/templates/ranks.html
@@ -171,10 +171,10 @@
     .tier-table { width: 100%; border-collapse: collapse; }
     .tier-table th { font-size: 11px; color: var(--text-tertiary); font-weight: 400; text-align: left; padding: 0 10px 10px; }
     .tier-table td { padding: 10px; border-top: 0.5px solid var(--border); font-size: 13px; vertical-align: middle; }
-    .tier-table tr.current td { background: var(--accent-light); }
-    .tier-table tr.current td:first-child { border-radius: 6px 0 0 6px; }
-    .tier-table tr.current td:last-child  { border-radius: 0 6px 6px 0; }
-    .tier-table tr.current td { border-top-color: transparent; }
+    /* Current-tier row: accent top border + highlight bg; remove gap below by hiding next row's top border */
+    .tier-table tr.current td { background: var(--accent-light); border-top: 2px solid var(--accent, #534AB7) !important; }
+    .tier-table tr.current td:first-child { border-left: 3px solid var(--accent, #534AB7); }
+    .tier-table tr.current + tr td { border-top-color: transparent; }
 
     /* ── Tooltip ── */
     .muscle-tooltip {

--- a/templates/social_list.html
+++ b/templates/social_list.html
@@ -3,8 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="csrf-token" content="{{ csrf_token() }}">
-  <title>{{ plan.title }} · LiftAGILE</title>
+  <title>{{ profile_user.username.title() }}'s {{ list_type | title }} · LiftAGILE</title>
   <script>
     if (performance.navigation && performance.navigation.type === 1) {
       sessionStorage.removeItem('liftlab-theme');
@@ -19,17 +18,6 @@
     }
   </script>
   <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
-  <style>
-    .detail-layout {
-      display: grid;
-      grid-template-columns: minmax(0,1.4fr) minmax(0,1fr);
-      gap: 16px;
-      align-items: start;
-    }
-    @media (max-width: 640px) {
-      .detail-layout { grid-template-columns: minmax(0, 1fr); }
-    }
-  </style>
 </head>
 <body>
 <div class="app-shell">
@@ -131,7 +119,7 @@
 
     {% if nav_user %}
     <a href="{{ url_for('public_profile', username=nav_user.username) }}"
-       class="nav-link {% if request.endpoint == 'public_profile' %}active{% endif %}"
+       class="nav-link {% if request.endpoint in ('public_profile', 'user_followers', 'user_following', 'user_plans') %}active{% endif %}"
        data-label="Public profile">
       <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
         <circle cx="8" cy="5.5" r="2.5" stroke="currentColor" stroke-width="1.5"/>
@@ -162,7 +150,9 @@
       {% include "_sidebar_avatar.html" %}
       <div class="nav-user-info">
         <div class="nav-user-name">{{ nav_user.username.title() if nav_user else "Profile" }}</div>
-        <div class="nav-user-rank">View profile</div>
+        <div class="nav-user-rank">
+          {% if nav_rank %}Rank #{{ nav_rank }}{% else %}View profile{% endif %}
+        </div>
       </div>
     </a>
 
@@ -180,127 +170,120 @@
       {% endif %}
     {% endwith %}
 
-    <div class="detail-layout">
-
-      <!-- Left: plan detail -->
-      <div style="display:flex;flex-direction:column;gap:14px;">
-        <div class="card">
-          <a href="{{ url_for('public_feed') }}"
-             style="font-size:12px;color:var(--text-tertiary);text-decoration:none;display:inline-block;margin-bottom:12px;">
-            ← Back to feed
-          </a>
-
-          <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:12px;margin-bottom:4px;">
-            <div>
-              <h1 class="page-title" style="margin-bottom:4px;">{{ plan.title }}</h1>
-              <span class="vis-badge {% if plan.is_public %}vis-public{% else %}vis-private{% endif %}">
-                {{ 'Public' if plan.is_public else 'Private' }}
-              </span>
-            </div>
-            {% if is_owner %}
-              <form action="{{ url_for('toggle_plan_visibility', plan_id=plan.id) }}" method="POST" style="flex-shrink:0;margin-top:4px;">
-                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                <button class="vis-toggle-btn {% if plan.is_public %}vis-toggle-private{% else %}vis-toggle-public{% endif %}" type="submit">
-                  {{ 'Make Private' if plan.is_public else 'Make Public' }}
-                </button>
-              </form>
-            {% endif %}
-          </div>
-
-          <p class="muted" style="margin-bottom:14px;">
-            Shared by
-            {% if plan.user %}
-              <a href="{{ url_for('public_profile', username=plan.user.username) }}"
-                 style="color:var(--accent);text-decoration:none;">{{ plan.user.username }}</a>
-            {% else %}
-              Unknown user
-            {% endif %}
-          </p>
-
-          <hr class="card-divider">
-
-          {% set plan_exercises = (plan.description or '').split(', ') | reject('equalto', '') | list %}
-          {% if plan_exercises %}
-            <div style="font-size:11px;color:var(--text-tertiary);margin-bottom:8px;letter-spacing:0.06em;text-transform:uppercase;font-weight:500;">
-              Exercises · {{ plan_exercises | length }}
-            </div>
-            <div style="display:flex;flex-direction:column;gap:6px;">
-              {% for ex in plan_exercises %}
-              <div style="display:flex;align-items:center;gap:10px;padding:8px 10px;background:var(--surface-raised,var(--bg-secondary));border-radius:var(--radius-sm,6px);font-size:13px;color:var(--text-primary);">
-                <div class="ex-icon cat-arms" style="width:24px;height:24px;font-size:10px;border-radius:5px;flex-shrink:0;display:flex;align-items:center;justify-content:center;font-weight:600;">
-                  {{ ex[0] | upper }}
-                </div>
-                <span>{{ ex }}</span>
-              </div>
-              {% endfor %}
-            </div>
-          {% else %}
-            <p style="font-size:13px;color:var(--text-secondary);line-height:1.6;">No exercises added.</p>
-          {% endif %}
-
-          <div class="workout-actions" style="margin-top:16px;">
-            <form action="{{ url_for('toggle_workout_like', plan_id=plan.id) }}" method="POST">
-              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-              <button class="btn {% if user_has_liked %}btn-primary{% else %}btn-secondary{% endif %}"
-                      type="submit" style="font-size:12px;padding:6px 16px;display:flex;align-items:center;gap:6px;">
-                <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-                  <path d="M8 13.5C4 11 1.5 8.5 1.5 5.5A3.5 3.5 0 018 3.6 3.5 3.5 0 0114.5 5.5C14.5 8.5 12 11 8 13.5z"
-                        stroke="currentColor" stroke-width="1.5"
-                        {% if user_has_liked %}fill="currentColor"{% endif %}/>
-                </svg>
-                {{ likes_count }} {{ "Like" if not user_has_liked else "Unlike" }}
-              </button>
-            </form>
-          </div>
-        </div>
-      </div>
-
-      <!-- Right: comments -->
-      <div class="card">
-        <div class="card-title">Comments ({{ comments | length }})</div>
-
-        <form action="{{ url_for('add_workout_comment', plan_id=plan.id) }}" method="POST"
-              class="comment-form">
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-          <textarea name="body" rows="3"
-                    placeholder="Write a comment…" required></textarea>
-          <button class="btn btn-primary" type="submit"
-                  style="font-size:12px;padding:6px 14px;">Post</button>
-        </form>
-
-        <hr class="card-divider">
-
-        <div class="comments-section" style="margin-top:0;">
-          {% if comments %}
-            {% for comment in comments %}
-              <div class="comment-card card" style="margin-bottom:8px;padding:12px;">
-                <div style="display:flex;align-items:center;gap:8px;margin-bottom:6px;">
-                  <div class="avatar" style="background:var(--purple-50);color:var(--purple-600);width:28px;height:28px;font-size:10px;flex-shrink:0;">
-                    {% if comment.user %}{{ comment.user.username[:2].upper() }}{% else %}?{% endif %}
-                  </div>
-                  <span style="font-size:13px;font-weight:500;">
-                    {% if comment.user %}{{ comment.user.username }}{% else %}User{% endif %}
-                  </span>
-                  <span class="muted" style="margin-left:auto;">
-                    {{ comment.created_at.strftime("%d %b") }}
-                  </span>
-                </div>
-                <p style="font-size:13px;color:var(--text-secondary);margin:0;line-height:1.5;">
-                  {{ comment.body }}
-                </p>
-              </div>
-            {% endfor %}
-          {% else %}
-            <p class="muted" style="text-align:center;padding:16px 0;">
-              No comments yet. Be the first!
-            </p>
-          {% endif %}
-        </div>
-      </div>
-
+    <!-- Page header -->
+    <div style="margin-bottom:20px;">
+      <a href="{{ url_for('public_profile', username=profile_user.username) }}" class="sl-back-link">
+        ← {{ profile_user.username.title() }}
+      </a>
+      <h1 class="page-title" style="margin-top:6px;font-size:20px;">
+        {{ profile_user.username.title() }}'s {{ list_type | title }}
+      </h1>
     </div>
-  </main>
 
+    {% if hidden %}
+
+      <!-- Hidden lists notice -->
+      <div class="sl-hidden card">
+        <div class="sl-hidden-icon">🔒</div>
+        <div class="sl-hidden-title">Lists are private</div>
+        <div class="sl-hidden-sub">This user only shares their followers and following lists with followers.</div>
+      </div>
+
+    {% else %}
+
+      <!-- Search bar -->
+      <form class="sl-search-form" method="GET" action="{{ request.path }}">
+        <div class="sl-search-wrap">
+          <svg class="sl-search-icon" width="15" height="15" viewBox="0 0 16 16" fill="none">
+            <circle cx="7" cy="7" r="4.5" stroke="currentColor" stroke-width="1.5"/>
+            <path d="M10.5 10.5L14 14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+          </svg>
+          <input
+            type="search"
+            name="q"
+            class="sl-search-input"
+            placeholder="Search {{ list_type }}..."
+            value="{{ q }}"
+            autocomplete="off"
+          >
+        </div>
+        {% if q %}
+          <a href="{{ request.path }}" class="sl-search-clear">Clear</a>
+        {% endif %}
+      </form>
+
+      <!-- User list -->
+      {% if users %}
+        <div class="sl-list">
+          {% for u in users %}
+            <div class="sl-user-row card">
+
+              <!-- Avatar -->
+              <a href="{{ url_for('public_profile', username=u.username) }}" class="sl-avatar-link">
+                {% if u.profile_photo %}
+                  <img src="{{ url_for('static', filename=u.profile_photo) }}"
+                       alt="{{ u.username }}"
+                       class="sl-avatar-img">
+                {% else %}
+                  <div class="sl-avatar-init">{{ u.username[:2].upper() }}</div>
+                {% endif %}
+              </a>
+
+              <!-- Name + bio -->
+              <div class="sl-user-info">
+                <a href="{{ url_for('public_profile', username=u.username) }}" class="sl-username">
+                  {{ u.username.title() }}
+                </a>
+                {% if u.bio %}
+                  <div class="sl-bio">{{ u.bio[:80] }}{% if u.bio | length > 80 %}…{% endif %}</div>
+                {% endif %}
+              </div>
+
+              <!-- Follow / Unfollow button -->
+              <div class="sl-user-action">
+                {% if u.id != current_user.id %}
+                  {% if u.id in following_ids %}
+                    <form action="{{ url_for('unfollow_user', user_id=u.id) }}" method="POST">
+                      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                      <input type="hidden" name="next" value="{{ request.url }}">
+                      <button type="submit" class="btn btn-secondary sl-action-btn">Unfollow</button>
+                    </form>
+                  {% else %}
+                    <form action="{{ url_for('follow_user', user_id=u.id) }}" method="POST">
+                      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                      <input type="hidden" name="next" value="{{ request.url }}">
+                      <button type="submit" class="btn btn-primary sl-action-btn">Follow</button>
+                    </form>
+                  {% endif %}
+                {% endif %}
+              </div>
+
+            </div>
+          {% endfor %}
+        </div>
+
+      {% else %}
+
+        <!-- Empty state -->
+        <div class="sl-empty card">
+          <div class="sl-empty-icon">👥</div>
+          {% if q %}
+            <div class="sl-empty-title">No results for "{{ q }}"</div>
+            <div class="sl-empty-sub">Try a different search term.</div>
+          {% elif list_type == 'followers' %}
+            <div class="sl-empty-title">No followers yet</div>
+            <div class="sl-empty-sub">{{ profile_user.username.title() }} doesn't have any followers yet.</div>
+          {% else %}
+            <div class="sl-empty-title">Not following anyone</div>
+            <div class="sl-empty-sub">{{ profile_user.username.title() }} isn't following anyone yet.</div>
+          {% endif %}
+        </div>
+
+      {% endif %}
+
+    {% endif %}
+
+  </main>
 </div>
 <script src="{{ url_for('static', filename='js/main.js') }}"></script>
 </body>

--- a/templates/user_plans.html
+++ b/templates/user_plans.html
@@ -3,8 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="csrf-token" content="{{ csrf_token() }}">
-  <title>{{ plan.title }} · LiftAGILE</title>
+  <title>{{ profile_user.username.title() }}'s Plans · LiftAGILE</title>
   <script>
     if (performance.navigation && performance.navigation.type === 1) {
       sessionStorage.removeItem('liftlab-theme');
@@ -19,17 +18,6 @@
     }
   </script>
   <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
-  <style>
-    .detail-layout {
-      display: grid;
-      grid-template-columns: minmax(0,1.4fr) minmax(0,1fr);
-      gap: 16px;
-      align-items: start;
-    }
-    @media (max-width: 640px) {
-      .detail-layout { grid-template-columns: minmax(0, 1fr); }
-    }
-  </style>
 </head>
 <body>
 <div class="app-shell">
@@ -131,7 +119,7 @@
 
     {% if nav_user %}
     <a href="{{ url_for('public_profile', username=nav_user.username) }}"
-       class="nav-link {% if request.endpoint == 'public_profile' %}active{% endif %}"
+       class="nav-link {% if request.endpoint in ('public_profile', 'user_followers', 'user_following', 'user_plans') %}active{% endif %}"
        data-label="Public profile">
       <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
         <circle cx="8" cy="5.5" r="2.5" stroke="currentColor" stroke-width="1.5"/>
@@ -162,7 +150,9 @@
       {% include "_sidebar_avatar.html" %}
       <div class="nav-user-info">
         <div class="nav-user-name">{{ nav_user.username.title() if nav_user else "Profile" }}</div>
-        <div class="nav-user-rank">View profile</div>
+        <div class="nav-user-rank">
+          {% if nav_rank %}Rank #{{ nav_rank }}{% else %}View profile{% endif %}
+        </div>
       </div>
     </a>
 
@@ -180,127 +170,84 @@
       {% endif %}
     {% endwith %}
 
-    <div class="detail-layout">
+    <!-- Page header -->
+    <div style="margin-bottom:20px;">
+      <a href="{{ url_for('public_profile', username=profile_user.username, tab='plans') }}" class="sl-back-link">
+        ← {{ profile_user.username.title() }}
+      </a>
+      <h1 class="page-title" style="margin-top:6px;font-size:20px;">
+        {{ profile_user.username.title() }}'s Workout Plans
+      </h1>
+    </div>
 
-      <!-- Left: plan detail -->
-      <div style="display:flex;flex-direction:column;gap:14px;">
-        <div class="card">
-          <a href="{{ url_for('public_feed') }}"
-             style="font-size:12px;color:var(--text-tertiary);text-decoration:none;display:inline-block;margin-bottom:12px;">
-            ← Back to feed
-          </a>
+    {% if plans %}
+      <div class="pp-plans-list">
+        {% for plan in plans %}
+          {% set likes      = likes_map.get(plan.id, 0) %}
+          {% set n_comments = comments_map.get(plan.id, 0) %}
+          {% set tags       = tags_map.get(plan.id, ['Workout Plan']) %}
+          <div class="pp-plan-card card">
 
-          <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:12px;margin-bottom:4px;">
-            <div>
-              <h1 class="page-title" style="margin-bottom:4px;">{{ plan.title }}</h1>
-              <span class="vis-badge {% if plan.is_public %}vis-public{% else %}vis-private{% endif %}">
-                {{ 'Public' if plan.is_public else 'Private' }}
-              </span>
+            <div class="pp-plan-title">
+              {{ plan.title }}
+              {% if is_own_profile %}
+                {% if plan.is_public %}
+                  <span class="vis-badge vis-public" style="font-size:10px;vertical-align:middle;margin-left:6px;">Public</span>
+                {% else %}
+                  <span class="vis-badge vis-private" style="font-size:10px;vertical-align:middle;margin-left:6px;">Private</span>
+                {% endif %}
+              {% endif %}
             </div>
-            {% if is_owner %}
-              <form action="{{ url_for('toggle_plan_visibility', plan_id=plan.id) }}" method="POST" style="flex-shrink:0;margin-top:4px;">
-                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                <button class="vis-toggle-btn {% if plan.is_public %}vis-toggle-private{% else %}vis-toggle-public{% endif %}" type="submit">
-                  {{ 'Make Private' if plan.is_public else 'Make Public' }}
-                </button>
-              </form>
-            {% endif %}
-          </div>
 
-          <p class="muted" style="margin-bottom:14px;">
-            Shared by
-            {% if plan.user %}
-              <a href="{{ url_for('public_profile', username=plan.user.username) }}"
-                 style="color:var(--accent);text-decoration:none;">{{ plan.user.username }}</a>
-            {% else %}
-              Unknown user
-            {% endif %}
-          </p>
-
-          <hr class="card-divider">
-
-          {% set plan_exercises = (plan.description or '').split(', ') | reject('equalto', '') | list %}
-          {% if plan_exercises %}
-            <div style="font-size:11px;color:var(--text-tertiary);margin-bottom:8px;letter-spacing:0.06em;text-transform:uppercase;font-weight:500;">
-              Exercises · {{ plan_exercises | length }}
-            </div>
-            <div style="display:flex;flex-direction:column;gap:6px;">
-              {% for ex in plan_exercises %}
-              <div style="display:flex;align-items:center;gap:10px;padding:8px 10px;background:var(--surface-raised,var(--bg-secondary));border-radius:var(--radius-sm,6px);font-size:13px;color:var(--text-primary);">
-                <div class="ex-icon cat-arms" style="width:24px;height:24px;font-size:10px;border-radius:5px;flex-shrink:0;display:flex;align-items:center;justify-content:center;font-weight:600;">
-                  {{ ex[0] | upper }}
-                </div>
-                <span>{{ ex }}</span>
+            {% if plan.description %}
+              <div class="pp-plan-desc">
+                {{ plan.description[:140] }}{% if plan.description | length > 140 %}…{% endif %}
               </div>
+            {% endif %}
+
+            <div class="fd-tags" style="margin-bottom:0;">
+              {% for tag in tags %}
+                <span class="fd-tag">{{ tag }}</span>
               {% endfor %}
             </div>
-          {% else %}
-            <p style="font-size:13px;color:var(--text-secondary);line-height:1.6;">No exercises added.</p>
-          {% endif %}
 
-          <div class="workout-actions" style="margin-top:16px;">
-            <form action="{{ url_for('toggle_workout_like', plan_id=plan.id) }}" method="POST">
-              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-              <button class="btn {% if user_has_liked %}btn-primary{% else %}btn-secondary{% endif %}"
-                      type="submit" style="font-size:12px;padding:6px 16px;display:flex;align-items:center;gap:6px;">
-                <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+            <div class="pp-plan-footer">
+              <span class="pp-plan-stat">
+                <svg width="13" height="13" viewBox="0 0 16 16" fill="none">
                   <path d="M8 13.5C4 11 1.5 8.5 1.5 5.5A3.5 3.5 0 018 3.6 3.5 3.5 0 0114.5 5.5C14.5 8.5 12 11 8 13.5z"
-                        stroke="currentColor" stroke-width="1.5"
-                        {% if user_has_liked %}fill="currentColor"{% endif %}/>
+                        stroke="currentColor" stroke-width="1.5"/>
                 </svg>
-                {{ likes_count }} {{ "Like" if not user_has_liked else "Unlike" }}
-              </button>
-            </form>
+                {{ likes }}
+              </span>
+              <span class="pp-plan-stat">
+                <svg width="13" height="13" viewBox="0 0 16 16" fill="none">
+                  <path d="M2 2h12a1 1 0 011 1v8a1 1 0 01-1 1H5l-3 3V3a1 1 0 011-1z"
+                        stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/>
+                </svg>
+                {{ n_comments }}
+              </span>
+              <a href="{{ url_for('workout_detail', plan_id=plan.id) }}"
+                 class="btn btn-secondary pp-plan-view">View Plan</a>
+            </div>
+
           </div>
-        </div>
+        {% endfor %}
       </div>
 
-      <!-- Right: comments -->
-      <div class="card">
-        <div class="card-title">Comments ({{ comments | length }})</div>
-
-        <form action="{{ url_for('add_workout_comment', plan_id=plan.id) }}" method="POST"
-              class="comment-form">
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-          <textarea name="body" rows="3"
-                    placeholder="Write a comment…" required></textarea>
-          <button class="btn btn-primary" type="submit"
-                  style="font-size:12px;padding:6px 14px;">Post</button>
-        </form>
-
-        <hr class="card-divider">
-
-        <div class="comments-section" style="margin-top:0;">
-          {% if comments %}
-            {% for comment in comments %}
-              <div class="comment-card card" style="margin-bottom:8px;padding:12px;">
-                <div style="display:flex;align-items:center;gap:8px;margin-bottom:6px;">
-                  <div class="avatar" style="background:var(--purple-50);color:var(--purple-600);width:28px;height:28px;font-size:10px;flex-shrink:0;">
-                    {% if comment.user %}{{ comment.user.username[:2].upper() }}{% else %}?{% endif %}
-                  </div>
-                  <span style="font-size:13px;font-weight:500;">
-                    {% if comment.user %}{{ comment.user.username }}{% else %}User{% endif %}
-                  </span>
-                  <span class="muted" style="margin-left:auto;">
-                    {{ comment.created_at.strftime("%d %b") }}
-                  </span>
-                </div>
-                <p style="font-size:13px;color:var(--text-secondary);margin:0;line-height:1.5;">
-                  {{ comment.body }}
-                </p>
-              </div>
-            {% endfor %}
-          {% else %}
-            <p class="muted" style="text-align:center;padding:16px 0;">
-              No comments yet. Be the first!
-            </p>
-          {% endif %}
-        </div>
+    {% else %}
+      <div class="sl-empty card">
+        <div class="sl-empty-icon">📋</div>
+        {% if is_own_profile %}
+          <div class="sl-empty-title">No plans yet</div>
+          <div class="sl-empty-sub">Head to <a href="{{ url_for('plans') }}" style="color:var(--accent);">My Plans</a> to create your first workout plan.</div>
+        {% else %}
+          <div class="sl-empty-title">No public plans yet</div>
+          <div class="sl-empty-sub">{{ profile_user.username.title() }} hasn't shared any public workout plans yet.</div>
+        {% endif %}
       </div>
+    {% endif %}
 
-    </div>
   </main>
-
 </div>
 <script src="{{ url_for('static', filename='js/main.js') }}"></script>
 </body>


### PR DESCRIPTION
## Title

feat: add social profile lists, privacy controls, and ranking fixes


closes #66, closes #68, closes #71

## Summary

This PR improves LiftAGILE’s social profile experience and fixes several ranking/data consistency issues.

Users can now view followers, following, and public plans in dedicated list-style pages, with privacy controls to hide follow lists from the public. This PR also fixes inconsistencies between the Leaderboard and My Ranks pages by separating their tier logic and recalibrating scoring thresholds.

## Changes Made

### Social Profile Lists

- Added followers and following list functionality for public profiles.
- Added searchable follower/following lists, similar to Instagram-style profile lists.
- Added public plans list access so users can view another user’s shared workout plans.
- Added `show_follow_lists` field to the `User` model.
- By default, followers and following lists are visible.
- Users can now toggle whether their followers/following lists are publicly visible.
- Follow lists are conditionally shown based on privacy settings and whether the viewer is allowed to access them.

### View Plan Bug Fix

- Fixed an issue where `workout_detail.html` displayed `plan.description` as raw comma-separated text.
- Updated the Workout Detail page so exercises are parsed and displayed as an individual exercise list.
- This now matches the display style used on the My Plans page.

### Leaderboard Tier Inflation Fix

- Fixed an issue where all 20 seed users were showing as Champion.
- Root cause was that `TIER_THRESHOLDS` was calibrated for smaller per-session scores, while the Leaderboard uses accumulated lifetime training volume.
- Updated leaderboard thresholds to match real accumulated workout volumes.

### Rank vs Leaderboard Consistency Fix

- Fixed inconsistency caused by My Ranks and Leaderboard sharing the same `TIER_THRESHOLDS`.
- Split the tier logic into:
  - `LEADERBOARD_TIER_THRESHOLDS`
  - `RANK_TIER_THRESHOLDS`
- Updated `get_tier()` to accept a thresholds parameter.
- Leaderboard and My Ranks now use separate scales appropriate to their different metrics.

### Seed Data Improvements

- Updated seed data so demo users have more varied training activity.
- Added `USER_ACTIVITY` to give users different workout frequencies.
- This spreads demo users across multiple tiers instead of clustering them all in Champion.
- Seed users now better demonstrate ranking differences across Champion, Emerald, Diamond, Platinum, and Gold tiers.

## Database / Model Changes

Added:

- `show_follow_lists` on the `User` model.

Existing local databases may need to be patched or recreated because `db.create_all()` does not automatically add new columns to existing tables.

For local development, the easiest reset is:

```bash
rm -f instance/users.db
python seed_data.py